### PR TITLE
updating pong, round, round~

### DIFF
--- a/hammer/pong.c
+++ b/hammer/pong.c
@@ -229,7 +229,7 @@ static void pong_list(t_pong *x, t_symbol *s, int argc, t_atom *argv){
 		float returnval, curterm;
 		curterm = atom_getfloatarg(i, argc, argv);
 		returnval = pong_ponger(curterm, minv, maxv, mode);
-		SETFLOAT((outatom+1), (t_float)returnval);
+		SETFLOAT((outatom+i), (t_float)returnval);
 	};
 	outlet_list(x->x_obj.ob_outlet, &s_list, argc, outatom);
 	ATOMS_FREEA(outatom, argc); //free allocated memory for outatom

--- a/hammer/pong.c
+++ b/hammer/pong.c
@@ -1,42 +1,197 @@
 #include "m_pd.h"
 #include <math.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdlib.h>
+
+#ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
+#define HAVE_ALLOCA 1
+#endif
+#define TEXT_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
+#if HAVE_ALLOCA
+#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < TEXT_NGETBYTE ?  \
+			        alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
+#define ATOMS_FREEA(x, n) ( \
+		    ((n) < TEXT_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
+#else
+#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
+#define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
+#endif
+
+#ifndef CYPONGMODE_DEF
+#define CYPONGMODE_DEF 0
+#endif
+
+#ifndef CYPONGLO_DEF
+#define CYPONGLO_DEF 0.
+#endif
+
+#ifndef CYPONGHI_DEF
+#define CYPONGHI_DEF 1.
+#endif
 
 static t_class *pong_class;
 
 typedef struct _pong {//pong (control rate) 
 	t_object x_obj;
-	int mode; //0 = fold, 1 = wrap
+	int mode; //0=none, 1 = clip, 2 = wrap, 3=fold
 	t_float minval;
 	t_float maxval;
 } t_pong;
 
-static void *pong_new(t_floatarg f1, t_floatarg f2, t_floatarg f3){
-	int _mode;
+
+
+
+static int pong_setmode_help(const char * mode){
+//helper function for setting mode
+int retmode; //int val for mode (see struct)
+	if(strcmp(mode, "clip") == 0){
+		retmode = 1;
+	}
+	else if(strcmp(mode, "wrap") == 0){
+		retmode = 2;
+	}
+	else if(strcmp(mode, "fold") == 0){
+		retmode = 3;
+	}
+	else{//default to none o/wise
+		retmode = 0;
+	};
+
+	return retmode;
+	
+};
+
+static void *pong_new(t_symbol *s, int argc, t_atom *argv){
+	//two optional args (lo, hi), then attributes for mode (str) and range (2 fl)
 	t_pong *x = (t_pong *)pd_new(pong_class);
-	if(f1 <= 0.){
-		_mode = 0;
-		}
-	else{
-		_mode = 1;
-		};
-	x->mode = _mode;
-	x->minval = f2;
-	x->maxval = f3;
+	int numargs = 0;//number of args read
+	x->minval = CYPONGLO_DEF;
+	x->maxval = CYPONGHI_DEF;
+	x->mode = CYPONGMODE_DEF;
+	while(argc > 0 ){
+		t_symbol *curarg = atom_getsymbolarg(0, argc, argv); //returns nullpointer if not symbol
+			if(curarg == &s_){ //if nullpointer, should be float or int
+				switch(numargs){
+					case 0: 	x->minval = atom_getfloatarg(0, argc, argv);
+								numargs++;
+								argc--;
+								argv++;
+								break;
+				
+					case 1: 	x->maxval = atom_getfloatarg(0, argc, argv);
+								numargs++;
+								argc--;
+								argv++;
+								break;
+				
+					default:	goto errstate;
+				};
+			}
+			else{
+			int isrange = strcmp(curarg->s_name, "@range") == 0;
+			int ismode = strcmp(curarg->s_name, "@mode") == 0;
+			if(isrange && argc >= 3){
+					t_symbol *arg1 = atom_getsymbolarg(1, argc, argv);
+					t_symbol *arg2 = atom_getsymbolarg(2, argc, argv);
+					if(arg1 == &s_ && arg2 == &s_){
+						x->minval = atom_getfloatarg(1, argc, argv);
+						x->maxval = atom_getfloatarg(2, argc, argv);
+						argc -= 3;
+						argv += 3;
+					}
+					else{
+						goto errstate;
+					};}
+	
+			else if(ismode && argc >= 2){
+					t_symbol *arg3 = atom_getsymbolarg(1, argc, argv);
+					if(arg3 != &s_){
+						x->mode = pong_setmode_help(arg3->s_name);
+						argc -= 2;
+						argv += 2;
+					}
+					else{
+						goto errstate;
+					};}
+			else{
+				goto errstate;
+			};	};
+	};
 
 	floatinlet_new(&x->x_obj, &x->minval);
 	floatinlet_new(&x->x_obj, &x->maxval);
 
-	outlet_new(&x->x_obj, &s_float);
+	outlet_new(&x->x_obj, gensym("list"));
 	return (x);
+	errstate:
+		pd_error(x, "pong: improper args");
+		return NULL;
+}
+
+
+static float pong_ponger(float input, float minval, float maxval, int mode){
+	//pong helper function
+	float returnval;
+	if(input <= maxval && input >= minval){//if input in range, return input
+		returnval = input;
+		}
+	else if(mode == 3){//folding
+		float range = maxval - minval;
+		if(input < minval){
+			float diff = minval - input; //diff between input and minimum (positive)
+			int mag = (int)(diff/range); //case where input is more than a range away from minval
+			if(mag % 2 == 0){// even number of ranges away = counting up from min
+				diff = diff - ((float)mag)*range;
+				returnval = diff + minval;
+				}
+			else{// odd number of ranges away = counting down from max
+				diff = diff - ((float)mag)*range;
+				returnval = maxval - diff;
+				};
+			}
+		else{ //input > maxval
+			float diff = input - maxval; //diff between input and max (positive)
+			int mag  = (int)(diff/range); //case where input is more than a range away from maxval
+			if(mag % 2 == 0){//even number of ranges away = counting down from max
+				diff = diff - (float)mag*range;
+				returnval = maxval - diff;
+				}
+			else{//odd number of ranges away = counting up from min
+				diff = diff - (float)mag*range;
+				returnval = diff + minval;
+				};
+			};
+		}
+	else if (mode == 2){// wrapping
+		returnval = fmod(input-minval,maxval-minval) + minval;
+	}
+	else if(mode == 1){//clipping
+		if(input < minval){
+			returnval = minval;
+		}
+		else{//input > maxval
+			returnval = maxval;
+		};
+	}
+	else{//mode = 0, no effect
+		returnval = input;
+	};
+
+	return returnval;
+
 }
 
 static void pong_float(t_pong *x, t_float f){
 	float returnval, minv, maxv, ipt;
 	int mode;
+	t_atom *outatom; //since outlet is of type list, need to use list of len 1 instead of float for output
 	mode = x->mode;
 	minv = x->minval;
 	maxv = x->maxval;
 	ipt = f;
+	
+	ATOMS_ALLOCA(outatom, 1); //allocate memory for outatom of len 1
 
 	if(minv > maxv){//checking ranges
 		float temp;
@@ -45,58 +200,72 @@ static void pong_float(t_pong *x, t_float f){
 		minv = temp;
 		};
 
-	if(ipt <= maxv && ipt >= minv){//if ipt in range, return ipt
-		returnval = ipt;
-		}
-	else if(mode == 0){//folding
-		float range = maxv - minv;
-		if(ipt < minv){
-			float diff = minv - ipt; //diff between input and minimum (positive)
-			int mag = (int)(diff/range); //case where ipt is more than a range away from minv
-			if(mag % 2 == 0){// even number of ranges away = counting up from min
-				diff = diff - ((float)mag)*range;
-				returnval = diff + minv;
-				}
-			else{// odd number of ranges away = counting down from max
-				diff = diff - ((float)mag)*range;
-				returnval = maxv - diff;
-				};
-			}
-		else{ //ipt > maxv
-			float diff = ipt - maxv; //diff between input and max (positive)
-			int mag  = (int)(diff/range); //case where ipt is more than a range away from maxv
-			if(mag % 2 == 0){//even number of ranges away = counting down from max
-				diff = diff - (float)mag*range;
-				returnval = maxv - diff;
-				}
-			else{//odd number of ranges away = counting up from min
-				diff = diff - (float)mag*range;
-				returnval = diff + minv;
-				};
-			};
-		}
-	else{//mode = 1, wrapping
-		returnval = fmod(ipt-minv,maxv-minv) + minv;
-	};
-
-
-	outlet_float(x->x_obj.ob_outlet, returnval);
+	returnval = pong_ponger(ipt, minv, maxv, mode);
+	SETFLOAT(outatom, (t_float)returnval);
+	outlet_list(x->x_obj.ob_outlet, &s_list, 1, outatom);
+	ATOMS_FREEA(outatom, 1); //free allocated memory for outatom
+	
 }
 
-static void pong_setmode(t_pong *x, t_float f){
-	int _mode;
-	if(f <= 0.){
-		_mode = 0;
-		}
-	else{
-		_mode = 1;
+
+static void pong_list(t_pong *x, t_symbol *s, int argc, t_atom *argv){
+
+	float minv, maxv;
+	int mode, i;
+	t_atom *outatom;
+	mode = x->mode;
+	minv = x->minval;
+	maxv = x->maxval;
+	
+	ATOMS_ALLOCA(outatom, argc); //allocate memory for outatom 
+
+	if(minv > maxv){//checking ranges
+		float temp;
+		temp = maxv;
+		maxv = minv;
+		minv = temp;
 		};
-	x->mode = _mode;
+	for(i=0; i<argc; i++){//use helper function to set outatom one by one
+		float returnval, curterm;
+		curterm = atom_getfloatarg(i, argc, argv);
+		returnval = pong_ponger(curterm, minv, maxv, mode);
+		SETFLOAT((outatom+1), (t_float)returnval);
+	};
+	outlet_list(x->x_obj.ob_outlet, &s_list, argc, outatom);
+	ATOMS_FREEA(outatom, argc); //free allocated memory for outatom
+	
 }
 
-void pong_setup(void){
+void pong_setrange(t_pong *x, t_float lo, t_float hi){
+	float minv, maxv;
+
+	minv = lo;
+	maxv = hi;
+	if(minv > maxv){//checking ranges
+		float temp;
+		temp = maxv;
+		maxv = minv;
+		minv = temp;
+		};
+
+	x->minval = minv;
+	x->maxval = maxv;
+
+}
+
+void pong_setmode(t_pong *x, t_symbol *s){
+	int setmode;
+
+	setmode = pong_setmode_help(s->s_name);
+	x->mode = setmode;
+	
+}
+
+	void pong_setup(void){
 	pong_class = class_new(gensym("pong"), (t_newmethod)pong_new, 0,
-			sizeof(t_pong), 0, A_DEFFLOAT, A_DEFFLOAT, A_DEFFLOAT, 0);
+			sizeof(t_pong), 0, A_GIMME, 0);
 	class_addfloat(pong_class, pong_float);
-	class_addmethod(pong_class, (t_method)pong_setmode, gensym("mode"), A_FLOAT, 0);
+	class_addlist(pong_class, pong_list);
+	class_addmethod(pong_class, (t_method)pong_setrange, gensym("range"), A_FLOAT, A_FLOAT, 0);
+	class_addmethod(pong_class, (t_method)pong_setmode, gensym("mode"), A_SYMBOL, 0);
 }

--- a/help/pong-help.pd
+++ b/help/pong-help.pd
@@ -1,9 +1,9 @@
-#N canvas 284 79 559 638 10;
-#X obj 0 589 cnv 15 552 21 empty empty empty 20 12 0 14 -233017 -33289
+#N canvas 813 137 564 747 10;
+#X obj 1 709 cnv 15 552 21 empty empty empty 20 12 0 14 -233017 -33289
 0;
-#X obj 0 185 cnv 3 550 3 empty empty inlets 8 12 0 13 -228856 -1 0
+#X obj 1 296 cnv 3 550 3 empty empty inlets 8 12 0 13 -228856 -1 0
 ;
-#N canvas 614 313 360 252 META 1;
+#N canvas 612 316 360 252 META 0;
 #X text 0 19 LICENSE SIBSD;
 #X text 0 133 LIBRARY cyclone;
 #X text 1 153 VERSION 0.2-beta1;
@@ -22,64 +22,92 @@ adapted the patch to pd-extended 2015-02-02;
 #X text 1 171 AUTHOR Derek Kwan;
 #X text 2 189 RELEASE_DATE 2016;
 #X text 0 114 OUTLET_0 float;
-#X restore 501 591 pd META;
-#X obj 0 344 cnv 3 550 3 empty empty outlets 8 12 0 13 -228856 -1 0
+#X restore 502 711 pd META;
+#X obj 1 455 cnv 3 550 3 empty empty outlets 8 12 0 13 -228856 -1 0
 ;
-#X obj 0 381 cnv 3 550 3 empty empty arguments 8 12 0 13 -228856 -1
+#X obj 1 492 cnv 3 550 3 empty empty arguments 8 12 0 13 -228856 -1
 0;
-#X obj 0 457 cnv 3 550 3 empty empty more_info 8 12 0 13 -228856 -1
+#X obj 1 653 cnv 3 550 3 empty empty more_info 8 12 0 13 -228856 -1
 0;
 #N canvas 312 452 428 109 Related_objects 0;
 #X obj 0 0 cnv 15 425 20 empty empty empty 3 12 0 14 -204280 -1 0;
 #X text 6 1 Related Objects;
-#X restore 197 591 pd Related_objects;
-#X obj 86 197 cnv 17 3 43 empty empty 0 5 9 0 16 -228856 -162280 0
+#X restore 198 711 pd Related_objects;
+#X obj 87 308 cnv 17 3 43 empty empty 0 5 9 0 16 -228856 -162280 0
 ;
-#X obj 86 354 cnv 17 3 17 empty empty 0 5 9 0 16 -228856 -162280 0
+#X obj 87 465 cnv 17 3 17 empty empty 0 5 9 0 16 -228856 -162280 0
 ;
 #X obj 0 0 cnv 15 552 40 empty empty pong 3 12 0 18 -204280 -1 0;
-#X text 112 250 float;
-#X text 193 248 - set low range;
-#X obj 86 298 cnv 17 3 33 empty empty 2 5 9 0 16 -228856 -162280 0
+#X text 113 361 float;
+#X obj 87 409 cnv 17 3 33 empty empty 2 5 9 0 16 -228856 -162280 0
 ;
-#X obj 86 252 cnv 17 3 33 empty empty 1 5 9 0 16 -228856 -162280 0
+#X obj 87 363 cnv 17 3 33 empty empty 1 5 9 0 16 -228856 -162280 0
 ;
-#X text 112 296 float;
-#X text 193 293 - set high range;
-#X text 193 212 - 0 for fold \, 1 for wrap;
-#X text 94 392 1) float;
-#X text 94 409 2) float;
-#X text 94 427 3) float;
-#X text 193 409 - default low value;
-#X text 193 427 - default high value;
-#X text 193 392 - mode (0 for fold \, 1 for wrap);
-#X text 120 85 lo val;
-#X text 274 87 hi val;
-#X floatatom 240 86 0 -100 100 0 - - -;
-#X floatatom 166 85 0 -100 100 0 - - -;
-#X floatatom 93 55 10 0 0 0 - - -, f 10;
-#X text 103 463 pong either folds or wraps its input within the range
-of a lo val and a hi val. The optional arguments are <mode> <lo val>
-<high val>. mode 0 is fold \, mode 1 is wrap. The default mode is fold.
-The default range is zero to one. If hi val is greater than lo val
-\, their behavior is swapped. All inlets accept both signals and floats.
-The mode <int> message may be used to switch between fold and wrap
-mode. It is useful for performing modulo arithmetic \, as well as foldover
-or wraparound distortion.;
-#X text 112 196 float;
-#X text 193 196 - number to wrap or fold;
-#X text 112 212 mode <int>;
-#X obj 240 108 / 100;
-#X obj 166 110 / 100;
+#X text 113 407 float;
+#X text 63 85 lo val;
+#X text 217 87 hi val;
+#X floatatom 183 86 0 -100 100 0 - - -;
+#X floatatom 109 85 0 -100 100 0 - - -;
+#X floatatom 36 55 10 0 0 0 - - -, f 10;
+#X text 113 307 float;
+#X text 168 310 - number to wrap or fold;
+#X obj 183 108 / 100;
+#X obj 109 110 / 100;
 #X obj 506 8 pong;
 #X text 16 23 fold or wrap float input within a given range;
-#X text 112 354 float;
-#X text 193 354 - wrapped or folded number;
-#X floatatom 93 160 10 0 0 0 - - -, f 10;
-#X obj 93 138 cyclone/pong 0 -0.25 0.25;
-#X connect 25 0 32 0;
-#X connect 26 0 33 0;
-#X connect 27 0 39 0;
-#X connect 32 0 39 2;
-#X connect 33 0 39 1;
-#X connect 39 0 38 0;
+#X text 113 465 float;
+#X floatatom 36 160 10 0 0 0 - - -, f 10;
+#X text 95 499 1) float;
+#X text 95 517 2) float;
+#X text 168 502 - optional low value (default = 0);
+#X text 168 520 - optional high value (default = 1);
+#X obj 1 560 cnv 3 550 3 empty empty attributes 8 12 0 13 -228856 -1
+0;
+#X text 92 575 @mode (sym);
+#X text 168 575 - set mode (none = default \, clip \, wrap \, fold)
+;
+#X text 104 659 pong is useful for performing modulo arithmetic \,
+as well as foldover or wraparound distortion.;
+#X text 168 592 - set range (low value \, high value);
+#X text 100 323 message;
+#X text 168 324 - "mode (sym)" sets mode (none = default \, clip \,
+wrap \, fold);
+#X text 74 591 @range (f) (f);
+#X text 168 337 - "range (f) (f)" sets low and high values of range
+;
+#X text 167 363 - set low value of range;
+#X text 168 407 - set high value of range;
+#X text 168 468 - original \, clipped \, wrapped \, or folded number
+;
+#X text 180 534 (if one float in argt \, specifies low val);
+#X floatatom 243 157 10 0 0 0 - - -, f 10;
+#X floatatom 32 263 10 0 0 0 - - -, f 10;
+#X floatatom 243 262 10 0 0 0 - - -, f 10;
+#X msg 332 213 range -0.5 0.5;
+#X text 333 192 change range via message;
+#X msg 332 106 mode none;
+#X text 330 82 change mode via message;
+#X obj 36 138 cyclone/pong 0 1 @mode clip;
+#X obj 243 135 cyclone/pong 0 1 @mode wrap;
+#X obj 243 240 cyclone/pong @mode clip @range -2 2;
+#X obj 32 241 cyclone/pong 0 1 @mode fold;
+#X connect 16 0 21 0;
+#X connect 17 0 22 0;
+#X connect 18 0 51 0;
+#X connect 18 0 52 0;
+#X connect 18 0 53 0;
+#X connect 18 0 54 0;
+#X connect 21 0 51 2;
+#X connect 21 0 52 2;
+#X connect 21 0 53 2;
+#X connect 21 0 54 2;
+#X connect 22 0 51 1;
+#X connect 22 0 52 1;
+#X connect 22 0 53 1;
+#X connect 22 0 54 1;
+#X connect 47 0 53 0;
+#X connect 49 0 52 0;
+#X connect 51 0 26 0;
+#X connect 52 0 44 0;
+#X connect 53 0 46 0;
+#X connect 54 0 45 0;

--- a/help/pong-help.pd
+++ b/help/pong-help.pd
@@ -1,14 +1,12 @@
-#N canvas 813 137 564 747 10;
-#X obj 1 709 cnv 15 552 21 empty empty empty 20 12 0 14 -233017 -33289
+#N canvas 811 140 559 744 10;
+#X obj 2 708 cnv 15 552 21 empty empty empty 20 12 0 14 -233017 -33289
 0;
-#X obj 1 296 cnv 3 550 3 empty empty inlets 8 12 0 13 -228856 -1 0
+#X obj 2 295 cnv 3 550 3 empty empty inlets 8 12 0 13 -228856 -1 0
 ;
-#N canvas 612 316 360 252 META 0;
+#N canvas 608 322 360 252 META 1;
 #X text 0 19 LICENSE SIBSD;
 #X text 0 133 LIBRARY cyclone;
 #X text 1 153 VERSION 0.2-beta1;
-#X text 3 208 WEBSITE http://suita.chopin.edu.pl/~czaja/miXed/externs/cyclone.html
-;
 #X text 3 240 HELP_PATCH_AUTHORS Christoph Kummerer. Revised by Jonathan
 Wilkes for Pd-extended 0.42 to conform to the PDDP template. Alex Cleveland
 updated this patch for Pd-l2ork version 2013.05.28. Fred Jan Kraan
@@ -16,72 +14,67 @@ adapted the patch to pd-extended 2015-02-02;
 #X text 0 0 KEYWORDS float fold wrap range;
 #X text 0 38 DESCRIPTION fold or wrap a float within a given range
 ;
-#X text 0 57 INLET_0 float mode;
 #X text 0 76 INLET_1 float;
 #X text 0 95 INLET_2 float;
 #X text 1 171 AUTHOR Derek Kwan;
 #X text 2 189 RELEASE_DATE 2016;
-#X text 0 114 OUTLET_0 float;
-#X restore 502 711 pd META;
-#X obj 1 455 cnv 3 550 3 empty empty outlets 8 12 0 13 -228856 -1 0
+#X text 0 57 INLET_0 float list message;
+#X text 0 114 OUTLET_0 float list;
+#X restore 503 710 pd META;
+#X obj 2 454 cnv 3 550 3 empty empty outlets 8 12 0 13 -228856 -1 0
 ;
-#X obj 1 492 cnv 3 550 3 empty empty arguments 8 12 0 13 -228856 -1
+#X obj 2 491 cnv 3 550 3 empty empty arguments 8 12 0 13 -228856 -1
 0;
-#X obj 1 653 cnv 3 550 3 empty empty more_info 8 12 0 13 -228856 -1
+#X obj 2 652 cnv 3 550 3 empty empty more_info 8 12 0 13 -228856 -1
 0;
 #N canvas 312 452 428 109 Related_objects 0;
 #X obj 0 0 cnv 15 425 20 empty empty empty 3 12 0 14 -204280 -1 0;
 #X text 6 1 Related Objects;
-#X restore 198 711 pd Related_objects;
-#X obj 87 308 cnv 17 3 43 empty empty 0 5 9 0 16 -228856 -162280 0
+#X restore 199 710 pd Related_objects;
+#X obj 88 307 cnv 17 3 43 empty empty 0 5 9 0 16 -228856 -162280 0
 ;
-#X obj 87 465 cnv 17 3 17 empty empty 0 5 9 0 16 -228856 -162280 0
+#X obj 88 464 cnv 17 3 17 empty empty 0 5 9 0 16 -228856 -162280 0
 ;
 #X obj 0 0 cnv 15 552 40 empty empty pong 3 12 0 18 -204280 -1 0;
-#X text 113 361 float;
-#X obj 87 409 cnv 17 3 33 empty empty 2 5 9 0 16 -228856 -162280 0
+#X text 114 360 float;
+#X obj 88 408 cnv 17 3 33 empty empty 2 5 9 0 16 -228856 -162280 0
 ;
-#X obj 87 363 cnv 17 3 33 empty empty 1 5 9 0 16 -228856 -162280 0
+#X obj 88 362 cnv 17 3 33 empty empty 1 5 9 0 16 -228856 -162280 0
 ;
-#X text 113 407 float;
+#X text 114 406 float;
 #X text 63 85 lo val;
 #X text 217 87 hi val;
 #X floatatom 183 86 0 -100 100 0 - - -;
 #X floatatom 109 85 0 -100 100 0 - - -;
 #X floatatom 36 55 10 0 0 0 - - -, f 10;
-#X text 113 307 float;
-#X text 168 310 - number to wrap or fold;
 #X obj 183 108 / 100;
 #X obj 109 110 / 100;
 #X obj 506 8 pong;
-#X text 16 23 fold or wrap float input within a given range;
-#X text 113 465 float;
 #X floatatom 36 160 10 0 0 0 - - -, f 10;
-#X text 95 499 1) float;
-#X text 95 517 2) float;
-#X text 168 502 - optional low value (default = 0);
-#X text 168 520 - optional high value (default = 1);
-#X obj 1 560 cnv 3 550 3 empty empty attributes 8 12 0 13 -228856 -1
+#X text 96 498 1) float;
+#X text 96 516 2) float;
+#X text 185 501 - optional low value (default = 0);
+#X text 185 519 - optional high value (default = 1);
+#X obj 2 559 cnv 3 550 3 empty empty attributes 8 12 0 13 -228856 -1
 0;
-#X text 92 575 @mode (sym);
-#X text 168 575 - set mode (none = default \, clip \, wrap \, fold)
+#X text 93 574 @mode (sym);
+#X text 185 574 - set mode (none = default \, clip \, wrap \, fold)
 ;
-#X text 104 659 pong is useful for performing modulo arithmetic \,
+#X text 105 658 pong is useful for performing modulo arithmetic \,
 as well as foldover or wraparound distortion.;
-#X text 168 592 - set range (low value \, high value);
-#X text 100 323 message;
-#X text 168 324 - "mode (sym)" sets mode (none = default \, clip \,
+#X text 185 591 - set range (low value \, high value);
+#X text 113 322 message;
+#X text 178 323 - "mode (sym)" sets mode (none = default \, clip \,
 wrap \, fold);
-#X text 74 591 @range (f) (f);
-#X text 168 337 - "range (f) (f)" sets low and high values of range
+#X text 75 590 @range (f) (f);
+#X text 178 339 - "range (f) (f)" sets low and high values of range
 ;
-#X text 167 363 - set low value of range;
-#X text 168 407 - set high value of range;
-#X text 168 468 - original \, clipped \, wrapped \, or folded number
+#X text 179 362 - set low value of range;
+#X text 180 409 - set high value of range;
+#X text 183 464 - original \, clipped \, wrapped \, or folded number
 ;
-#X text 180 534 (if one float in argt \, specifies low val);
+#X text 197 533 (if one float in argt \, specifies low val);
 #X floatatom 243 157 10 0 0 0 - - -, f 10;
-#X floatatom 32 263 10 0 0 0 - - -, f 10;
 #X floatatom 243 262 10 0 0 0 - - -, f 10;
 #X msg 332 213 range -0.5 0.5;
 #X text 333 192 change range via message;
@@ -90,24 +83,32 @@ wrap \, fold);
 #X obj 36 138 cyclone/pong 0 1 @mode clip;
 #X obj 243 135 cyclone/pong 0 1 @mode wrap;
 #X obj 243 240 cyclone/pong @mode clip @range -2 2;
+#X obj 32 263 print ponglist;
+#X msg 29 215 -2.02 1.59 -0.62 3.63 9.54;
+#X text 34 192 can also input lists;
+#X text 114 306 float/list;
+#X text 178 307 - number(s) to wrap or fold;
+#X text 114 464 float/list;
 #X obj 32 241 cyclone/pong 0 1 @mode fold;
-#X connect 16 0 21 0;
-#X connect 17 0 22 0;
-#X connect 18 0 51 0;
-#X connect 18 0 52 0;
-#X connect 18 0 53 0;
-#X connect 18 0 54 0;
-#X connect 21 0 51 2;
-#X connect 21 0 52 2;
-#X connect 21 0 53 2;
-#X connect 21 0 54 2;
-#X connect 22 0 51 1;
-#X connect 22 0 52 1;
-#X connect 22 0 53 1;
-#X connect 22 0 54 1;
-#X connect 47 0 53 0;
-#X connect 49 0 52 0;
-#X connect 51 0 26 0;
-#X connect 52 0 44 0;
-#X connect 53 0 46 0;
-#X connect 54 0 45 0;
+#X text 16 23 fold or wrap float or list input within a given range
+;
+#X connect 16 0 19 0;
+#X connect 17 0 20 0;
+#X connect 18 0 46 0;
+#X connect 18 0 47 0;
+#X connect 18 0 48 0;
+#X connect 19 0 46 2;
+#X connect 19 0 47 2;
+#X connect 19 0 48 2;
+#X connect 19 0 55 2;
+#X connect 20 0 46 1;
+#X connect 20 0 47 1;
+#X connect 20 0 48 1;
+#X connect 20 0 55 1;
+#X connect 42 0 48 0;
+#X connect 44 0 47 0;
+#X connect 46 0 22 0;
+#X connect 47 0 40 0;
+#X connect 48 0 41 0;
+#X connect 50 0 55 0;
+#X connect 55 0 49 0;

--- a/help/round-help.pd
+++ b/help/round-help.pd
@@ -1,4 +1,4 @@
-#N canvas 974 192 565 576 10;
+#N canvas 972 195 565 576 10;
 #X obj 0 541 cnv 15 552 21 empty empty empty 20 12 0 14 -233017 -33289
 0;
 #X obj 0 237 cnv 3 550 3 empty empty inlets 8 12 0 13 -228856 -1 0
@@ -50,7 +50,6 @@ adapted the patch to pd-extended 2015-02-02;
 #X text 156 62 change mode;
 #X obj 0 449 cnv 3 550 3 empty empty attributes 8 12 0 13 -228856 -1
 0;
-#X text 91 464 @nearest;
 #X text 178 464 - set mode (1 = round \, 0 = truncate);
 #X text 178 426 - optional value to round to (default = 0 \, no rounding)
 ;
@@ -71,11 +70,12 @@ adapted the patch to pd-extended 2015-02-02;
 #X obj 24 129 cyclone/round 0.5;
 #X obj 160 127 cyclone/round 0.5 @nearest 0;
 #X obj 375 125 cyclone/round 3;
-#X connect 14 0 36 0;
-#X connect 15 0 36 0;
-#X connect 29 0 35 0;
-#X connect 29 0 36 0;
-#X connect 32 0 37 0;
+#X text 91 464 @nearest (int);
+#X connect 14 0 35 0;
+#X connect 15 0 35 0;
+#X connect 28 0 34 0;
+#X connect 28 0 35 0;
+#X connect 31 0 36 0;
+#X connect 34 0 29 0;
 #X connect 35 0 30 0;
-#X connect 36 0 31 0;
-#X connect 37 0 33 0;
+#X connect 36 0 32 0;

--- a/help/round~-help.pd
+++ b/help/round~-help.pd
@@ -1,4 +1,4 @@
-#N canvas 134 291 563 547 10;
+#N canvas 132 294 563 547 10;
 #X obj 0 505 cnv 15 552 21 empty empty empty 20 12 0 14 -233017 -33289
 0;
 #X obj 0 237 cnv 3 550 3 empty empty inlets 8 12 0 13 -228856 -1 0
@@ -69,16 +69,16 @@ adapted the patch to pd-extended 2015-02-02;
 #X text 104 298 signal/float;
 #X obj 0 413 cnv 3 550 3 empty empty attributes 8 12 0 13 -228856 -1
 0;
-#X text 91 428 @nearest;
 #X text 178 428 - set mode (1 = round \, 0 = truncate);
 #X text 178 390 - optional value to round to (default = 0 \, no rounding)
 ;
 #X obj 118 162 cyclone/round~ 0.5;
 #X obj 269 160 cyclone/round~ 0.5 @nearest 0;
 #X text 107 242 signal/float;
+#X text 91 428 @nearest (int);
 #X connect 11 0 12 0;
+#X connect 12 0 38 0;
 #X connect 12 0 39 0;
-#X connect 12 0 40 0;
 #X connect 13 0 17 0;
 #X connect 14 0 15 0;
 #X connect 15 0 13 0;
@@ -86,11 +86,11 @@ adapted the patch to pd-extended 2015-02-02;
 #X connect 16 0 14 0;
 #X connect 16 0 30 0;
 #X connect 21 0 22 0;
+#X connect 28 0 38 1;
 #X connect 28 0 39 1;
-#X connect 28 0 40 1;
 #X connect 29 0 28 0;
 #X connect 30 0 29 0;
-#X connect 31 0 40 0;
-#X connect 32 0 40 0;
-#X connect 39 0 13 0;
-#X connect 40 0 21 0;
+#X connect 31 0 39 0;
+#X connect 32 0 39 0;
+#X connect 38 0 13 0;
+#X connect 39 0 21 0;

--- a/sickle/round.c
+++ b/sickle/round.c
@@ -3,6 +3,15 @@
 #include <string.h>
 #include <ctype.h>
 
+#ifndef CYROUNDNEAR_DEF
+#define CYROUNDNEAR_DEF 1
+#endif
+
+#ifndef CYROUNDNUM_DEF
+#define CYROUNDNUM_DEF 0.
+#endif
+
+
 static t_class *round_tilde_class;
 
 typedef struct _round_tilde
@@ -12,68 +21,58 @@ typedef struct _round_tilde
 	float x_nearest; //nearest attribute (1 = rounding, 0 = truncation)
 } t_round_tilde;
 
-static int checknum(const char *s)
-{
-	while(*s){
-		if (isdigit(*s++) == 0) return 0;
-	};
-	return 1;
-}
 
 static void *round_tilde_new(t_symbol *s, int argc, t_atom *argv)
 { float f;
-	int argcheck; //bool for checking arguments
 	t_round_tilde *x = (t_round_tilde *)pd_new(round_tilde_class);
-	if(argc == 1){	//one argument should be the rounded number
-		t_symbol *firstarg = atom_getsymbolarg(0, argc, argv);
-		x->x_nearest = 1;
-		argcheck = checknum(firstarg->s_name);
-		if(argcheck == 0){
-			pd_error(x, "round~: improper args");
-			return NULL;
-		}
-		else{
-			f = atom_getfloatarg(0, argc, argv);
-		};
-	};
-	if(argc == 2){ //two args should be '@nearest' and nearest arg
-		t_symbol *firstarg = atom_getsymbolarg(0, argc, argv);
-		f = 0.;
-		if(strcmp(firstarg->s_name, "@nearest")==0){
-			x->x_nearest = atom_getfloatarg(1, argc, argv);
-		}
-		else{
-			pd_error(x, "round~: improper args");
-			return NULL;
-		};
-	};
-	if(argc == 3){
-		t_symbol *firstarg = atom_getsymbolarg(0, argc, argv);
-		argcheck = checknum(firstarg->s_name);
-		if(argcheck == 1){//first arg is rounded number
-			f = atom_getfloatarg(0, argc, argv);
-			t_symbol *secondarg = atom_getsymbolarg(1, argc, argv);
-			if(strcmp(secondarg->s_name, "@nearest")==0){//second arg is '@nearest'
-				x->x_nearest = atom_getfloatarg(2, argc, argv);
+
+		int numargs = 0;
+		x->x_nearest = CYROUNDNEAR_DEF;
+		f = CYROUNDNUM_DEF;
+		while(argc > 0 ){
+			t_symbol *curarg = atom_getsymbolarg(0, argc, argv); //returns nullpointer if not symbol
+			if(curarg == &s_){ //if nullpointer, should be float or int
+				switch(numargs){
+					case 0: 	f = atom_getfloatarg(0, argc, argv);
+								numargs++;
+								argc--;
+								argv++;
+								break;
+				
+					default:	goto errstate;
+				};
 			}
 			else{
-				pd_error(x, "round~: improper args");
-				return NULL;
-			};
-		}
-		else{
-			pd_error(x, "round~: improper args");
-			return NULL;
-		};
+				int isnear = strcmp(curarg->s_name, "@nearest") == 0;
+				if(isnear && argc >= 2){
+					t_symbol *arg1 = atom_getsymbolarg(1, argc, argv);
+					if(arg1 == &s_){// is a number
+						x->x_nearest = atom_getfloatarg(1, argc, argv);
+						argc -= 2;
+						argv += 2;
+						}
+					else{
+						goto errstate;
+					};}
+				else{
+					goto errstate;
+					};	};
 	};
-	if(!argc || argc < 1){
-		x->x_nearest = 1;
-		f = 0.;
-	};
+
+
+
+
+
+
+
+
 	pd_float( (t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal), f);
 	 outlet_new(&x->x_obj, gensym("signal"));
 	return (x);
 	
+	errstate:
+		pd_error(x, "round~: improper args");
+		return NULL;
 }
 static t_int *round_tilde_perform(t_int *w)
 {


### PR DESCRIPTION
I updated pong to take attributes. This parses argv one arg at a time. I've also updated round and round~ with this method of parsing arguments and attributes. I've updated pong-help to reflect my changes, and round-help and round~-help to be a clearer about what nearest accepts. My checknum methods in round and round~ were also broken and it was coincidental it was working. When you try to atom_getsymbolarg on a float atom, it returns &s_. This function is found in pure data's src/m_atom.c . I've updated round.c and round~.c to reflect these changes.

Pong also now takes lists. 