### PR TITLE
updating pong, fixing pong~

### DIFF
--- a/hammer/pong.c
+++ b/hammer/pong.c
@@ -259,19 +259,9 @@ static void pong_list(t_pong *x, t_symbol *s, int argc, t_atom *argv){
 }
 
 static void pong_setrange(t_pong *x, t_float lo, t_float hi){
-	float minv, maxv;
 
-	minv = lo;
-	maxv = hi;
-	if(minv > maxv){//checking ranges
-		float temp;
-		temp = maxv;
-		maxv = minv;
-		minv = temp;
-		};
-
-	x->minval = minv;
-	x->maxval = maxv;
+	x->minval = lo;
+	x->maxval = hi;
 
 }
 


### PR DESCRIPTION
i changed pong~ so it only instantiates with 3 inlets now. I figured out how to set the value of a signal inlet internally,.. that's what that pd_float() method actually does! I also added a method to free the pong~ inlets upon destruction. something i edited in both pong and pong~, i sorted the inputs so that x->minval was always smaller than x->maxval despite the ordering in the "range (f)(f)" message,..  I don't really think it should be like that, i already do that sorting in the perform and float/list functions and i could see where it could get confusing ,.. like if you're seeing "range 1 0",.. it'll act like 0 is the min and 1 is the max,.. but then you want to change the 0,.. so of course you change maxval,.. but you're actually changing the 1 internally. so yeah, i got rid of those while setting the range. 