### PR TITLE
fixing typo in trapezoid_hi

### DIFF
--- a/sickle/trapezoid.c
+++ b/sickle/trapezoid.c
@@ -32,7 +32,7 @@ static void trapezoid_lo(t_trapezoid *x, t_floatarg f)
 
 static void trapezoid_hi(t_trapezoid *x, t_floatarg f)
 {
-	x->x_high = x->x_high;
+	x->x_high = f;
     x->x_range = f - x->x_low;
 }
 


### PR DESCRIPTION
fixing typo in trapezoid_hi,.. this should work now as I just tested the attributes