### PR TITLE
updating count~ and snapshot~

### DIFF
--- a/classes/binaries/signal/count.c
+++ b/classes/binaries/signal/count.c
@@ -2,14 +2,20 @@
  * For information on usage and redistribution, and for a DISCLAIMER OF ALL
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
+//updating argument parsing on object creation and adding autoreset attribute - Derek Kwan 2016
+#include <string.h>
 #include "m_pd.h"
-#include "sickle/sic.h"
 
-#define COUNTMAXINT 0x7fffffff 
+#define COUNTMAXINT 0x7fffffff
+
+#define PDCYCMINV 0.
+#define PDCYCMAXV 0.
+#define PDCYCONFL 0
+#define PDCYCAUTO 0 
 
 typedef struct _count
 {
-    t_sic  x_sic;
+    t_object x_obj;
     t_float  x_lastin;
     int    x_min;
     int    x_max;
@@ -150,24 +156,74 @@ static void *count_new(t_floatarg minval, t_floatarg maxval,
 {
     t_count *x = (t_count *)pd_new(count_class);
     x->x_lastin = 0;
+	t_float minval, maxval, onflag, autoflag;
+	minval = PDCYCMINV;
+	maxval = PDCYCMAXV;
+	onflag = PDCYCONFL;
+	autoflag = PDCYCAUTO;
+	int argnum = 0;
+	while(argc > 0){
+		if(argv -> a_type == A_FLOAT){
+			t_float argval = atom_getfloatarg(0, argc, argv);
+			switch(argnum){
+				case 0:
+					minval = argval;
+					break;
+				case 1:
+					maxval = argval;
+					break;
+				case 2:
+					onflag = argval;
+					break;
+				case 3:
+					autoflag = argval;
+					break;
+				default:
+					break;
+				};
+			argnum++;
+			argc--;
+			argv++;
+			}
+		else if(argv -> a_type == A_SYMBOL){
+			t_symbol * curarg = atom_getsymbolarg(0, argc, argv);
+			if(strcmp(curarg->s_name, "@autoreset") == 0){
+				if(argc >= 2){
+					t_float argval = atom_getfloatarg(1, argc, argv);
+					autoflag = argval;
+				}
+				else{
+					goto errstate;
+				};
+			}
+			else{
+				goto errstate;
+			};
+		}
+		else{
+			goto errstate;
+		};
+
+	};
     count_min(x, minval);
     count_max(x, maxval);
     x->x_on = (onflag != 0);
     count_autoreset(x, autoflag);
     x->x_count = x->x_min;
-    inlet_new((t_object *)x, (t_pd *)x, &s_float, gensym("ft1"));
-    outlet_new((t_object *)x, &s_signal);
+    inlet_new(&x->x_obj, &x->x_obj.ob_pd,&s_float, gensym("ft1"));
+    outlet_new(&x->x_obj, &s_signal);
     return (x);
 }
 
 void count_tilde_setup(void)
 {
     count_class = class_new(gensym("count~"), (t_newmethod)count_new, 0,
-        sizeof(t_count), 0, A_DEFFLOAT, A_DEFFLOAT, A_DEFFLOAT, A_DEFFLOAT, 0);
-    sic_setup(count_class, count_dsp, count_float);
-    class_addbang(count_class, count_bang);
-    class_addfloat(count_class, count_float);
-    class_addlist(count_class, count_list);
+        sizeof(t_count), 0, A_GIMME, 0);
+	class_domainsignalin(count_class, -1);
+	class_addfloat(count_class, (t_method)count_float);
+    class_addmethod(count_class, (t_method)count_dsp, gensym("dsp"), A_CANT, 0);
+    class_addbang(count_class, (t_method)count_bang);
+    class_addlist(count_class, (t_method)count_list);
     class_addmethod(count_class, (t_method)count_max,
 		    gensym("ft1"), A_FLOAT, 0);
     class_addmethod(count_class, (t_method)count_autoreset,

--- a/classes/binaries/signal/count.c
+++ b/classes/binaries/signal/count.c
@@ -151,8 +151,7 @@ static void count_dsp(t_count *x, t_signal **sp)
     dsp_add(count_perform, 4, x, sp[0]->s_n, sp[0]->s_vec, sp[1]->s_vec);
 }
 
-static void *count_new(t_floatarg minval, t_floatarg maxval,
-		       t_floatarg onflag, t_floatarg autoflag)
+static void *count_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_count *x = (t_count *)pd_new(count_class);
     x->x_lastin = 0;

--- a/classes/binaries/signal/snapshot.c
+++ b/classes/binaries/signal/snapshot.c
@@ -208,10 +208,10 @@ void snapshot_tilde_setup(void)
         (t_newmethod)snapshot_new, (t_method)snapshot_free, sizeof(t_snapshot), 0, A_GIMME,0);
     class_addcreator((t_newmethod)snapshot_new, gensym("cyclone/snapshot~"), A_GIMME, 0);
     class_addcreator((t_newmethod)snapshot_new, gensym("cyclone/Snapshot~"), A_GIMME, 0);
-    class_addmethod(snapshot_class, (t_method)snapshot_dsp, gensym("dsp"), A_CANT, 0);
 	class_domainsignalin(snapshot_class, -1);
 	class_addfloat(snapshot_class, (t_method)snapshot_float);
-    class_addbang(snapshot_class, snapshot_bang);
+    class_addmethod(snapshot_class, (t_method)snapshot_dsp, gensym("dsp"), A_CANT, 0);
+    class_addbang(snapshot_class, (t_method)snapshot_bang);
     class_addmethod(snapshot_class, (t_method)snapshot_ft1,
 		    gensym("ft1"), A_FLOAT, 0);
     class_addmethod(snapshot_class, (t_method)snapshot_offset,

--- a/classes/binaries/signal/snapshot.c
+++ b/classes/binaries/signal/snapshot.c
@@ -6,7 +6,6 @@
 //updating argument parsing for object creation, adding interval and active attributes - Derek Kwan 2016
 #include <string.h>
 #include "m_pd.h"
-#include "sickle/sic.h"
 
 /* CHECKME for a fixed minimum deltime, if any (5ms for c74's metro) */
 


### PR DESCRIPTION
I've updated count~ and snapshot~ and updated the argument parsing so they accept attributes (the argc, argv thing). I've also de-sic-ified both of them. However, I have no idea if they work or even build since the Makefile seems to be gonked. I am getting this error with the Makefile even with just "make", let alone "make clean" or "make install":

`Makefile:436: *** missing separator.  Stop.`

This error seems to be in the linux part of the Makefile so it may not affect you.

Also,  not to be pedantic about naming, but I think "binaries" isn't the right word for the folder of c files. If I'm not mistaken, binaries would refer to the built objects (and thus the pd_linuxes or pd_darwins), while the source c files would normally be called "source" or more succinctly "src". I like the "signal" and "control" bits though =).