### PR TITLE
fixing indents in makefile,updating record~,fixing one matrix~ bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,8 +487,8 @@ include pd-lib-builder/Makefile.pdlibbuilder
 install: install-aliases
 install-aliases: all
 ifeq ($(uname), Linux)
-    $(INSTALL_DIR) -v $(installpath)
-    cd $(installpath); \
+	$(INSTALL_DIR) -v $(installpath)
+	cd $(installpath); \
         ln -s -f append.$(extension) Append.$(extension); \
         ln -s -f append-help.pd Append-help.pd; \
         ln -s -f borax.$(extension) Borax.$(extension); \

--- a/classes/binaries/signal/matrix.c
+++ b/classes/binaries/signal/matrix.c
@@ -531,7 +531,7 @@ static void *matrix_new(t_symbol *s, int argc, t_atom *argv)
 					};
 					break;
 				case 2:
-					x->x_defgain = MATRIX_DEFGAIN;
+					x->x_defgain = argval;
 					break;
 				default:
 					break;


### PR DESCRIPTION
the makefile had two indents in 490 and 491 that were causing things not to work for me so i reindented them.

updated record~ to parse args. not sure what the default loopend is so I assumed that to be the length of the array, that took some figuring out since I needed to figure out the array length, which I swiped from an external arraysize, i think it's one of the first google results. 

i was (accidentally) just setting x->defgain in matrix~ to just the default even if it was specified which hopefully fixes the matrix_connect bug (because I didn't touch the matrix_connect method at all). That other bug will take more figuring out because I don't know exactly how it's doing everything.
