### PR TITLE
fixing monochannel in record/arsic

### DIFF
--- a/classes/binaries/signal/record.c
+++ b/classes/binaries/signal/record.c
@@ -89,12 +89,14 @@ static void record_mstoindex(t_record *x)
 {
     t_arsic *sic = (t_arsic *)x;
     x->x_startindex = (int)(x->x_startpoint * sic->s_ksr);
-    if (x->x_startindex < 0)
-	x->x_startindex = 0;  /* CHECKED */
+    if (x->x_startindex < 0){
+		x->x_startindex = 0;  /* CHECKED */
+	};
     x->x_endindex = (int)(x->x_endpoint * sic->s_ksr);
     if (x->x_endindex > sic->s_vecsize
-	|| x->x_endindex <= 0)
-	x->x_endindex = sic->s_vecsize;  /* CHECKED (both ways) */
+	|| x->x_endindex <= 0){
+		x->x_endindex = sic->s_vecsize;  /* CHECKED (both ways) */
+	};
     record_setsync(x);
 }
 
@@ -263,15 +265,17 @@ static void *record_new(t_symbol *s, int argc, t_atom *argv)
 	t_float loopstart = PDCYREC_LOOPSTART;
 	t_float loopend = -1;
 	
-	t_symbol * arrname;
-	//first arg HAS to be array name, parse it now
-	if(argv ->a_type == A_SYMBOL){
+	t_symbol * arrname = gensym("record_def");
+	if(argc > 0 && argv ->a_type == A_SYMBOL){
+		//first arg HAS to be array name, parse it now
 		arrname = atom_getsymbolarg(0, argc, argv);
 		argc--;
 		argv++;
+		//post("record~ setting to '%s'", arrname->s_name);
 	}
 	else{
-		goto errstate;
+	// else default to dummy name but warn
+		post("defaulting to name '%s'", arrname->s_name);
 	};
 	
 	//NOW parse the rest of the args
@@ -342,7 +346,10 @@ static void *record_new(t_symbol *s, int argc, t_atom *argv)
 	};
     /* one auxiliary signal:  sync output */
     int chn_n = (int)numchan > 4 ? 4 : (int)numchan;
-    t_record *x = (t_record *)arsic_new(record_class, arrname, chn_n == 3 ? 2 : chn_n, 0, 1);
+	if(chn_n == 3){
+		chn_n = 2;
+	};
+    t_record *x = (t_record *)arsic_new(record_class, arrname, chn_n, 0, 1);
     if (x)
     {
 	
@@ -356,15 +363,17 @@ static void *record_new(t_symbol *s, int argc, t_atom *argv)
 	record_append(x, append);	
 	record_loop(x, loopstatus);
 	record_reset(x);
-	record_startpoint(x, loopstart);
-	record_endpoint(x, loopend); 
 	x->x_clock = clock_new(x, (t_method)record_tick);
 	x->x_clocklasttick = clock_getlogicaltime();
-	while (--nch)
+	while (--nch){
 	    inlet_new((t_object *)x, (t_pd *)x, &s_signal, &s_signal);
+	};
 	inlet_new((t_object *)x, (t_pd *)x, &s_float, gensym("ft-2"));
 	inlet_new((t_object *)x, (t_pd *)x, &s_float, gensym("ft-1"));
 	outlet_new((t_object *)x, &s_signal);
+
+	record_startpoint(x, loopstart);
+	record_endpoint(x, loopend); 
     }
     return (x);
 	errstate:

--- a/classes/binaries/signal/scope.c
+++ b/classes/binaries/signal/scope.c
@@ -1182,7 +1182,7 @@ static void *scope_new(t_symbol *s, int argc, t_atom *argv)
     x->x_height = (int)height;
 	*/
 	//x->x_allocsize = 0;
-	x->x_allocsize = SCOPE_DEFBUFSIZE;
+	x->x_allocsize =  (int) SCOPE_DEFBUFSIZE;
 	x->x_xbuffer = x->x_xbufini;
 	x->x_ybuffer = x->x_ybufini;
     x->x_bufsize = 0;

--- a/shared/sickle/arsic.c
+++ b/shared/sickle/arsic.c
@@ -152,7 +152,7 @@ void *arsic_new(t_class *c, t_symbol *s,
     t_int *perfargs = 0;
     t_symbol **channames = 0;
     if (!s) s = &s_;
-    if (nchannels < 1)
+    if (nchannels <= 1)
     {
 	nchannels = 1;
 	mononame = s;


### PR DESCRIPTION
if no array name is given, i'm defaulting to "record_def" array. I suppose we can change the name of this if you want. Of course, chances are record_def won't exist either. 

arsic had this weird thing that if you specified 1 channel, it wouldn't default to the mono case (only not specifying would do that, which would make numchannels passed to arsic 0, then it would set the number of channels was 1). This was weird, so I just changed it, which fixes the mono case. I figure this was because the old version was using A_DEFFLOAT, which according to my inquiry on the pd-list, defaults to 0.

I checked the old record~ by using pd-l2ork, where my install only uses the old cyclone,. and setting append before recording anything would cause the phase to be stuck at -1 and not record too. I'd agree that this is weird behavior and makes append hard to use so I'll have to look into this issue in a future commit.

Also, the labeling of inlets in the help file is weird. If n is the number of inlets of record~ and you 0 index, then n-1 is the biggest inlet index (since [0..n-1] has n inlets and [0..n] has n+1 inlets). Also, I find it somewhat confusing because i'd normally consider n being the number of channels (not sure why, perhaps force of habit), which further confuses the situation.

