### PR TITLE
i seem to have gotten rid of warnings in record~

### DIFF
--- a/classes/binaries/signal/record.c
+++ b/classes/binaries/signal/record.c
@@ -40,6 +40,8 @@ typedef struct _record
     int       x_isrunning;   /* to know if sync should be 0.0 or 1.0 */
     t_clock  *x_clock;
     double    x_clocklasttick;
+
+	int 	  x_numchan;
 } t_record;
 
 static t_class *record_class;
@@ -47,10 +49,17 @@ static t_class *record_class;
 
 static t_float record_getarraysmp(t_record *x, t_symbol *arrayname){
   t_garray *garray;
+	char bufname[MAXPDSTRING];
 	t_float retsmp = -1;
-
+	int numchan = x->x_numchan;
+	if(numchan > 1){
+		sprintf(bufname, "0-%s", arrayname->s_name);
+	}
+	else{
+		sprintf(bufname, "%s", arrayname->s_name);
+	};
   if(!(garray = (t_garray *)pd_findbyclass(arrayname,garray_class))) {
-    pd_error(x, "%s: no such table", arrayname->s_name);
+    pd_error(x, "%s: no such table", bufname);
   } else {
    	retsmp = garray_npoints(garray);
   };
@@ -347,6 +356,7 @@ static void *record_new(t_symbol *s, int argc, t_atom *argv)
     {
 	
 	int nch = arsic_getnchannels((t_arsic *)x);
+	x->x_numchan = nch;
 	t_float arraysmp = record_getarraysmp(x, arrname);
 	if(loopend < 0 && arraysmp > 0){
 //if loopend not set or less than 0 and arraysmp doesn't fail, set it to arraylen in ms

--- a/shared/common/vefl.c
+++ b/shared/common/vefl.c
@@ -43,8 +43,9 @@ t_word *vefl_get(t_symbol *name, int *vszp, int indsp, t_pd *complain)
 	    else loud_error(complain,  /* always complain */
 			    "bad template of array '%s'", name->s_name);
 	}
-	else if (complain)
+	else if (complain){
 	    loud_error(complain, "no such array '%s'", name->s_name);
+	};
     }
     return (0);
 }
@@ -133,8 +134,9 @@ int vefl_renew(t_vefl *vp, t_symbol *name, t_pd *complain)
 #endif  /* LATER check all the cases and decide... */
 	if (!(vp->v_garray = (t_garray *)pd_findbyclass(name, garray_class)))
 	{
-	    if (complain)
+	    if (complain){
 		loud_error(complain, "no such array '%s'", name->s_name);
+		};
 	}
 	else if (!garray_getfloatwords(vp->v_garray, &vp->v_size, &vp->v_data))
 	{

--- a/shared/sickle/arsic.c
+++ b/shared/sickle/arsic.c
@@ -77,7 +77,7 @@ int arsic_getnchannels(t_arsic *x)
 }
 
 void arsic_setarray(t_arsic *x, t_symbol *s, int complain)
-{
+{ 	
     if (s)
     {
 	if (x->s_mononame) x->s_mononame = s;
@@ -152,36 +152,42 @@ void *arsic_new(t_class *c, t_symbol *s,
     t_int *perfargs = 0;
     t_symbol **channames = 0;
     if (!s) s = &s_;
-    if (nchannels <= 1)
-    {
-	nchannels = 1;
-	mononame = s;
-	stub = 0;
+    if (nchannels <= 1){
+		nchannels = 1;
+		mononame = s;
+		stub = 0;
     }
-    else
-    {
-	mononame = 0;
-	stub = s->s_name;
-    }
-    if (!(vectors = (t_float **)getbytes(nchannels * sizeof(*vectors))))
-	return (0);
-    if (nauxsigs > 0)
-	nperfargs = nchannels + nauxsigs + 2;
-    else if (nsigs > 0)
-	nperfargs = nsigs + 2;
-    if (nperfargs
+    else{
+		mononame = 0;
+		stub = s->s_name;
+    };
+    if (!(vectors = (t_float **)getbytes(nchannels * sizeof(*vectors)))){
+		return (0);
+	};
+    
+	if (nauxsigs > 0){
+		nperfargs = nchannels + nauxsigs + 2;
+	}
+    else if (nsigs > 0){
+		nperfargs = nsigs + 2;
+	};
+
+	if (nperfargs
 	&& !(perfargs = (t_int *)getbytes(nperfargs * sizeof(*perfargs))))
     {
-	freebytes(vectors, nchannels * sizeof(*vectors));
-	return (0);
-    }
-    if (stub &&
+		freebytes(vectors, nchannels * sizeof(*vectors));
+		return (0);
+    };
+    
+	if (stub &&
 	!(channames = (t_symbol **)getbytes(nchannels * sizeof(*channames))))
     {
-	freebytes(vectors, nchannels * sizeof(*vectors));
-	if (perfargs) freebytes(perfargs, nperfargs * sizeof(*perfargs));
+		freebytes(vectors, nchannels * sizeof(*vectors));
+		if (perfargs){
+			freebytes(perfargs, nperfargs * sizeof(*perfargs));
+			};
 	return (0);
-    }
+    };
     x = (t_arsic *)pd_new(c);
     x->s_vecsize = 0;
     x->s_nchannels = nchannels;


### PR DESCRIPTION
It was in my code all along! I still contend that arsic and vefl are unintuitive and messy...

I wasn't taking into account the prefixes in getarraysmp. so now i added a member of the struct x_numchan which stores the number of channels,.. if it's more than 1,.. prefix 0- to the array name so you just get the sample length from the first array,..  it looks like you don't need it in lookup because it doesn't look like you're dealing with channel multiplication,... but it uses arsic as well? I start to think I understand this code,.. but then i don't lol