### PR TITLE
adding selector

### DIFF
--- a/classes/binaries/signal/selector.c
+++ b/classes/binaries/signal/selector.c
@@ -1,4 +1,4 @@
-// Derek Kwan - 20166
+// Derek Kwan - 2016
 
 #include "m_pd.h"
 #include <math.h>

--- a/classes/binaries/signal/selector.c
+++ b/classes/binaries/signal/selector.c
@@ -1,79 +1,110 @@
-// Porres 2016
+// Derek Kwan - 20166
 
 #include "m_pd.h"
+#include <math.h>
+
+#define PDCYSELTORSIGPUT 1 //default number of sigputs (inlets without selector inlet)
+#define PDCYSELTORSTATE 0 //default state (0 = closed)
 
 typedef struct _selector
 {
     t_object   x_obj;
-    t_float    x_main_in;
-    t_float    x_inputs;
+	t_float *x_mainsig; //the main signal being piped in
+    int 	  x_sigputs; //inlets excluding selector idx (1 indexed)
+	t_float   x_state; //0 = closed, nonzero = index of inlet to pass (1 indexed)
     t_float  **x_ivecs; // copying from matrix
-    t_float  **x_ovecs; // copying from matrix
+    t_float  *x_ovec; // only should be single pointer since we're dealing with an array
+						//rather than an array of arrays
 } t_selector;
 
 static t_class *selector_class;
 
+
 static t_int *selector_perform(t_int *w)
 {
     t_selector *x = (t_selector *)(w[1]);
-    int nblock = (t_int)(w[2]);
-    t_float *in = (t_float *)(w[3]);
-    t_float *chn1 = (t_float *)(w[4]);
-    t_float *out = (t_float *)(w[5]);
-    while (nblock--)
-    {
-        *out++ = (int)*in++ == 1 ? *chn1++ : 0;
-    }
-    return (w + 6);
+    int nblock = (int)(w[2]);
+	
+	t_float *state = x->x_mainsig;
+    t_float **ivecs = x->x_ivecs;
+    t_float *ovec = x->x_ovec;
+
+	int i,j;
+
+	int sigputs = x->x_sigputs;
+
+	for(i=0; i< nblock; i++){
+		int curst = (int)state[i];
+		t_float output = 0;
+		if(curst != 0){
+			for(j=0; j<sigputs;j++){
+				if(curst == (j+1)){
+					output = ivecs[j][i];
+				};
+			};
+		};
+		ovec[i] = output;
+	};
+    return (w + 3);
 }
+
 
 static void selector_dsp(t_selector *x, t_signal **sp)
-{
-    dsp_add(selector_perform, 5, x, sp[0]->s_n,
-	    sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec);
-}
-
-/* static void selector_dsp(t_selector *x, t_signal **sp) // trying to copy from matrix...
-{
-    int i;
-    t_float **vecp = x->x_ivecs;
+{ 	
+	
+	
+	int i, nblock = sp[0]->s_n;
     t_signal **sigp = sp;
-    for (i = 0; i < x->x_inputs; i++)
-    {
-    *vecp++ = (*sigp++)->s_vec;
-    }
-    vecp = x->x_ovecs;
-    for (i = 0; i < 1; i++) *vecp++ = (*sigp++)->s_vec;
-    dsp_add(selector_perform, 2, x, sp[0]->s_n);
-} */
+	x->x_mainsig = (*sigp++)->s_vec; //the first sig in is the selector idx
+    for (i = 0; i < x->x_sigputs; i++){ //now for the sigputs
+		*(x->x_ivecs+i) = (*sigp++)->s_vec;
+	};
+	x->x_ovec = (*sigp++)->s_vec; //now for the outlet
+	dsp_add(selector_perform, 2, x, nblock);
+}
 
 static void *selector_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_selector *x = (t_selector *)pd_new(selector_class);
-    x->x_inputs = 2;
+    t_float sigputs = (t_float) PDCYSELTORSIGPUT; //inlets not counting selector input
+	t_float state = (t_float) PDCYSELTORSTATE; //start off closed initially
     int i;
     int argnum = 0;
-    while(argc > 0)
-    {
-        if(argv -> a_type == A_FLOAT)
-        {
+    while(argc > 0){
+        if(argv -> a_type == A_FLOAT){
             t_float argval = atom_getfloatarg(0, argc, argv);
-            switch(argnum)
-            {
+            switch(argnum){
                 case 0:
-                    if(argval < 1) x->x_inputs = 2;
-                    else x->x_inputs = (int)argval + 1;
+					sigputs = argval;
                     break;
+				case 1:
+					state = argval;
+					break;
                 default:
                     break;
             };
             argc--;
             argv++;
             argnum++;
-        }
-    }
-    for (i = 1; i < x->x_inputs; i++)
-    {
+        };
+    };
+
+	//bounds checking
+	if(sigputs < (t_float)PDCYSELTORSIGPUT){
+		sigputs = PDCYSELTORSIGPUT;
+	};
+	if(state < 0){
+		state = 0;
+	}
+	else if(state > sigputs){
+		state = sigputs;
+	};
+
+	x->x_sigputs = (int)sigputs;
+	x->x_state = state; 
+	x->x_ivecs = getbytes(sigputs * sizeof(*x->x_ivecs));
+    
+	for (i = 0; i < sigputs; i++){
         pd_float((t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal), 0.);
     };
     outlet_new((t_object *)x, &s_signal);
@@ -85,5 +116,5 @@ void selector_tilde_setup(void)
     selector_class = class_new(gensym("selector~"), (t_newmethod)selector_new, 0,
             sizeof(t_selector), CLASS_DEFAULT, A_GIMME, 0);
     class_addmethod(selector_class, (t_method)selector_dsp, gensym("dsp"), A_CANT, 0);
-    CLASS_MAINSIGNALIN(selector_class, t_selector, x_main_in);
+    CLASS_MAINSIGNALIN(selector_class, t_selector, x_state);
 }


### PR DESCRIPTION
so as you can see, i pretty much scrapped all the code and redid it lol. i also changed the authorship at the top since i did that if you don't mind. the way selector_dsp worked is basically similar to how all other dsp methods work. what's notable is that you don't have to pass the entire signal off to the perform method, you can just feed the signal right into the members of the class struct without having passing them to perform. that fact is illustrated here. and i was segfaulting for the longest time and i couldn't figure out why so i rewrote the perform method how i finally understood what was going on,.. on each block, you're basically passed the signal as a float array with n elements,.... sounds simple i know, but it took a while for it to click lol. the other perform methods all used while loops which kinda hide this fact. 

i'm counting the main inlet as a separate entity and all the other inlets which you are sorting out as sigputs. so x_sigputs is just the number of those. you originally were counting that main inlet as one of those and it just didn't feel intuitive to me. 

i haven't really tried out the second argt yet so if you have any problems with it, let me know. 