### PR TITLE
adding the redone lookup~

### DIFF
--- a/classes/binaries/signal/lookup.c
+++ b/classes/binaries/signal/lookup.c
@@ -1,130 +1,151 @@
-/* Copyright (c) 2002-2003 krzYszcz and others.
- * For information on usage and redistribution, and for a DISCLAIMER OF ALL
- * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
-
-/* LATER reconsider making float/int conversions
-   more compatible (and less useful). */
+//old code scrapped, brand new code by Derek Kwan - 2016
 
 #include "m_pd.h"
-#include "shared.h"
-#include "sickle/sic.h"
-#include "sickle/arsic.h"
+#include <math.h>
 
-// typedef t_arsic t_lookup;
-
-typedef struct _lookup
-{
-    t_arsic   x_arsic;
-    t_float   x_array_samp;  // array size in samples
-} t_lookup;
-
+#define CYLKUP_DEFSIZE 512
 
 static t_class *lookup_class;
 
-#define LOOKUP_DEFSIZE  512
+typedef struct _lookup
+{
+	t_object x_obj;
+	t_symbol *x_arrayname;
+	t_word *x_vec;
+	t_float x_f; //dummy variable
+	int x_npoints; //arraysize in samples
 
-static t_float lookup_getarraysmp(t_lookup *x, t_symbol *arrayname){
-    t_garray *garray;
-    t_float lkpsmp = -1;
-    
-    if(!(garray = (t_garray *)pd_findbyclass(arrayname,garray_class))) {
-        pd_error(x, "%s: no such table", arrayname->s_name);
-    } else {
-        lkpsmp = garray_npoints(garray);
-    };
-    return lkpsmp;
-}
+	t_inlet *x_offlet; //inlet for offset
+	t_inlet *x_sizelet; //inlet for lookup size
+	t_outlet *x_out; //outlet
+} t_lookup;
 
 static void lookup_set(t_lookup *x, t_symbol *s)
 {
-    arsic_setarray((t_arsic *)x, s, 1);
-    x->x_array_samp = lookup_getarraysmp(x, s);
+    t_garray *a;
+
+    x->x_arrayname = s;
+    if (!(a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class)))
+    {
+        if (*s->s_name){
+            pd_error(x, "lookup~: %s: no such array", x->x_arrayname->s_name);
+		};
+        x->x_vec = 0;
+    }
+    else if (!garray_getfloatwords(a, &x->x_npoints, &x->x_vec))
+    {
+        pd_error(x, "%s: bad template for lookup~", x->x_arrayname->s_name);
+        x->x_vec = 0;
+    }
+    else garray_usedindsp(a);
 }
 
-static void lookup_float(t_lookup *x, t_float f)
-{
-    pd_error(x, "lookup~: no method for 'float'");
+static void *lookup_new(t_symbol *s, t_floatarg offset, t_floatarg lookupsz){ 
+	t_lookup *x = (t_lookup *)pd_new(lookup_class);
+
+	if(!s){ //null t_symbol
+		s = &s_;
+	};
+
+	if(offset < 0){
+		offset = 0;
+	}
+	else{
+		offset = (t_float)floor(offset); //basically typecasting to int without actual typecasting
+	};
+	if(lookupsz <= 0){
+		lookupsz = CYLKUP_DEFSIZE;
+	}
+	else{
+		lookupsz = (t_float)floor(lookupsz);
+	};
+
+	x->x_arrayname = s;
+	x->x_offlet = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+	x->x_sizelet = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+	pd_float((t_pd *)x->x_offlet, offset);
+	pd_float( (t_pd *)x->x_sizelet, lookupsz);
+	x->x_out = outlet_new(&x->x_obj, gensym("signal"));
+	
+	return (x);
 }
 
 static t_int *lookup_perform(t_int *w)
 {
-    t_arsic *sic = (t_arsic *)(w[1]);
-    int nblock = (int)(w[2]);
-    t_float *out = (t_float *)(w[6]);
-    t_lookup *x = (t_lookup *)sic;
-    float array_maxsize = x->x_array_samp;
-    if (sic->s_playable)
-    {	
-	t_float *xin = (t_float *)(w[3]);
-	t_float *oin = (t_float *)(w[4]);
-	t_float *sin = (t_float *)(w[5]);
-	int vecsize = sic->s_vecsize;
-	t_word *vec = sic->s_vectors[0];  /* playable implies nonzero (mono) */
-	while (nblock--)
-	{
-	    float off = *oin++;  /* msp: converted to int (if not a signal) */
-	    int siz = (int)*sin++ - 1;  /* msp: converted to int (signal too) */
-        if(siz >= array_maxsize)
-            siz = array_maxsize - 1;
-	    float pos;
-//	    pos = (siz > 0 ? off + siz * (*xin++ + 1.0) * 0.5 : off);  // range: off - (off + siz)
-	    pos = (siz > 0 ? off + (siz - off) * (*xin++ + 1.0) * 0.5 : off);  // range: off - siz
-	    int ndx = (int)pos;
-	    int ndx1 = ndx + 1;
-	    if (ndx1 > 0 && ndx1 < vecsize)
-	    {
-		float val = vec[ndx].w_float;
-		*out++ = val + (vec[ndx1].w_float - val) * (pos - ndx);
-	    }
-	    /* CHECKED: */
-	    else if (ndx1 == 0) *out++ = vec[0].w_float * (pos + 1.0);
-	    else if (ndx1 == vecsize) *out++ = vec[ndx].w_float * (ndx1 - pos);
-	    else *out++ = 0;
-	}
-    }
-    else while (nblock--) *out++ = 0;
-    return (w + 7);
+	t_lookup *x = (t_lookup *)(w[1]);
+	t_float *phase = (t_float *)(w[2]);
+	t_float *offset = (t_float *)(w[3]);
+	t_float *lookupsz = (t_float *)(w[4]);
+	t_float *out = (t_float *)(w[5]);
+	int n = (int)(w[6]);
+	int npoints = x->x_npoints;
+	int maxidx = npoints -1;
+	t_word *buf = x->x_vec;
+
+	int i;
+	for(i=0;i<n;i++){
+		double curout = 0.f;
+		double curphs = phase[i]; //current phase
+		int curlupsz = (int)lookupsz[i]; //current lookup size
+		int curoff = (int)offset[i]; //current offset
+
+		//bounds checking
+		if(curlupsz > npoints){
+			curlupsz = npoints;
+		};
+		if(curoff < 0){
+			curoff = 0;
+		}
+		else if(curoff > maxidx){
+			curoff = maxidx;
+		};
+
+		if(curphs >= -1 && curphs <= 1 && buf){
+			//if phase if b/w -1 and 1, map and read, else 0
+			//mapping curphs to the realidx where -1 maps to offset and 1 maps to offset + lookupsz - 1
+			//resulting in mappings to lookupsz indices (if offset = 0, and lookupsz = 9, 8 is the maxidx to map to)
+			int realidx; //the real mapped idx in the buffer
+			realidx = curoff + (int)((curphs+1.f) * 0.5f * (curlupsz-1));
+
+			//bounds checking
+			if(realidx > maxidx){
+				realidx = maxidx;
+			};
+			curout = buf[realidx].w_float; //read the buffer!
+		};
+
+		out[i] = curout;
+	};
+	
+	return (w+7);
 }
 
 static void lookup_dsp(t_lookup *x, t_signal **sp)
 {
-    arsic_dsp((t_arsic *)x, sp, lookup_perform, 1);
+	lookup_set(x, x->x_arrayname);
+	dsp_add(lookup_perform, 6, x, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec, sp[0]->s_n);
 }
 
-static void lookup_free(t_lookup *x)
+static void *lookup_free(t_lookup *x)
 {
-    arsic_free((t_arsic *)x);
+	inlet_free(x->x_offlet);
+	inlet_free(x->x_sizelet);
+	outlet_free(x->x_out);
+	return (void *)x;
 }
 
-static void *lookup_new(t_symbol *s, t_floatarg f1, t_floatarg f2)
-{
-    /* CHECKED: lookup~ always uses the first channel in a multi-channel buffer~
-       (as the refman says). */
-    /* three auxiliary signals: amplitude, offset and size inputs */
-    t_lookup *x = (t_lookup *)arsic_new(lookup_class, s, 0, 0, 3);
-    if (x)
-    {
-	arsic_setminsize((t_arsic *)x, 2);
-	if (f1 < 0) f1 = 0;
-	if (f2 <= 0) f2 = LOOKUP_DEFSIZE;
-    t_float arraysmp = lookup_getarraysmp(x, s);
-	if (f2 >= arraysmp) f2 = arraysmp;
-	sic_newinlet((t_sic *)x, f1);
-	sic_newinlet((t_sic *)x, f2);
-	outlet_new((t_object *)x, &s_signal);
-    x->x_array_samp = arraysmp;
-    }
-    return (x);
-}
 
 void lookup_tilde_setup(void)
 {
-    lookup_class = class_new(gensym("lookup~"),
+   lookup_class = class_new(gensym("lookup~"),
 			     (t_newmethod)lookup_new,
 			     (t_method)lookup_free,
 			     sizeof(t_lookup), 0,
 			     A_DEFSYM, A_DEFFLOAT, A_DEFFLOAT, 0);
-    arsic_setup(lookup_class, lookup_dsp, lookup_float);
+
+    CLASS_MAINSIGNALIN(lookup_class, t_lookup, x_f);
+    class_addmethod(lookup_class, (t_method)lookup_dsp,
+        gensym("dsp"), A_CANT, 0);
     class_addmethod(lookup_class, (t_method)lookup_set,
 		    gensym("set"), A_SYMBOL, 0);
 }


### PR DESCRIPTION
adding my redone lookup~

for some reason when i test, i HAVE to make my setup method have _tilde (so it's lookup_tilde_setup), i dunno if that's the case with you. I suppose it's prob the way pd parses symbols to see what setup method to call? i don't remember having to do it for any other signal class in cyclone, so if it's not working, look at that first and perhaps make it just lookup_setup. i could be mistaken about the whole thing though and it's just way too late lol.