### PR TITLE
updating lookup~

### DIFF
--- a/classes/binaries/signal/lookup.c
+++ b/classes/binaries/signal/lookup.c
@@ -3,7 +3,7 @@
 #include "m_pd.h"
 #include <math.h>
 
-#define CYLKUP_DEFSIZE 512
+#define CYLKUPENDPT 512
 
 static t_class *lookup_class;
 
@@ -15,8 +15,8 @@ typedef struct _lookup
 	t_float x_f; //dummy variable
 	int x_npoints; //arraysize in samples
 
-	t_inlet *x_offlet; //inlet for offset
-	t_inlet *x_sizelet; //inlet for lookup size
+	t_inlet *x_offlet; //inlet for stpt
+	t_inlet *x_sizelet; //inlet for endpoint
 	t_outlet *x_out; //outlet
 } t_lookup;
 
@@ -40,31 +40,66 @@ static void lookup_set(t_lookup *x, t_symbol *s)
     else garray_usedindsp(a);
 }
 
-static void *lookup_new(t_symbol *s, t_floatarg offset, t_floatarg lookupsz){ 
+static void *lookup_new(t_symbol *s, int argc, t_atom *argv){ 
 	t_lookup *x = (t_lookup *)pd_new(lookup_class);
 
-	if(!s){ //null t_symbol
-		s = &s_;
+	t_symbol * name;
+	int nameset = 0; //flag if name is set
+	int floatarg = 0;//argument counter for floatargs (don't include symbol arg)
+	//setting defaults for start and end points
+	t_float stpt = 0;
+	t_float endpt = CYLKUPENDPT;
+
+	while(argc){
+		if(argv -> a_type == A_SYMBOL){
+			if(floatarg == 0){
+				//we haven't hit any floatargs, go ahead and set name
+				name = atom_getsymbolarg(0, argc, argv);
+				nameset = 1; //set nameset flag
+			};
+		}
+		else{
+			//else we're dealing with a float
+			switch(floatarg){
+				case 0:
+					stpt = atom_getfloatarg(0, argc, argv);
+					break;
+				case 1:
+					endpt = atom_getfloatarg(0, argc, argv);
+					break;
+				default:
+					break;
+			};
+			floatarg++; //increment the floatarg we're looking at
+		};
+		argc--;
+		argv++;
 	};
 
-	if(offset < 0){
-		offset = 0;
-	}
-	else{
-		offset = (t_float)floor(offset); //basically typecasting to int without actual typecasting
-	};
-	if(lookupsz <= 0){
-		lookupsz = CYLKUP_DEFSIZE;
-	}
-	else{
-		lookupsz = (t_float)floor(lookupsz);
+	if(!nameset){
+		//if name isn't set, set to null symbol
+		name = &s_;
 	};
 
-	x->x_arrayname = s;
+	//boundschecking
+	if(stpt < 0){
+		stpt = 0;
+	}
+	else{
+		stpt = (t_float)floor(stpt); //basically typecasting to int without actual typecasting
+	};
+	if(endpt < 0){
+		endpt = 0;
+	}
+	else{
+		endpt = (t_float)floor(endpt);
+	};
+
+	x->x_arrayname = name;
 	x->x_offlet = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
 	x->x_sizelet = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-	pd_float((t_pd *)x->x_offlet, offset);
-	pd_float( (t_pd *)x->x_sizelet, lookupsz);
+	pd_float((t_pd *)x->x_offlet, stpt);
+	pd_float( (t_pd *)x->x_sizelet, endpt);
 	x->x_out = outlet_new(&x->x_obj, gensym("signal"));
 	
 	return (x);
@@ -74,8 +109,8 @@ static t_int *lookup_perform(t_int *w)
 {
 	t_lookup *x = (t_lookup *)(w[1]);
 	t_float *phase = (t_float *)(w[2]);
-	t_float *offset = (t_float *)(w[3]);
-	t_float *lookupsz = (t_float *)(w[4]);
+	t_float *stpt = (t_float *)(w[3]);
+	t_float *endpt = (t_float *)(w[4]);
 	t_float *out = (t_float *)(w[5]);
 	int n = (int)(w[6]);
 	int npoints = x->x_npoints;
@@ -86,33 +121,45 @@ static t_int *lookup_perform(t_int *w)
 	for(i=0;i<n;i++){
 		double curout = 0.f;
 		double curphs = phase[i]; //current phase
-		int curlupsz = (int)lookupsz[i]; //current lookup size
-		int curoff = (int)offset[i]; //current offset
+		int curendpt = (int)endpt[i]; //current endpoint
+		int curstpt = (int)stpt[i]; //current start point
+		int cursz; //current size
+		int curdir = 1.f; //current direction
+
+		
+		//if curstpt is bigger than curendpt, swap them and change the direction
+		if(curstpt > curendpt){
+			int temp;
+			temp = curstpt;
+			curstpt = curendpt;
+			curendpt = temp;
+			curdir *= -1.f;
+		};
+		
 
 		//bounds checking
-		if(curlupsz > npoints){
-			curlupsz = npoints;
+		if(curendpt > npoints){
+			curendpt = npoints;
 		};
-		if(curoff < 0){
-			curoff = 0;
+		if(curstpt < 0){
+			curstpt = 0;
 		}
-		else if(curoff > maxidx){
-			curoff = maxidx;
+		else if(curstpt > maxidx){
+			curstpt = maxidx;
 		};
-
-		//think of lookup size as always counting from 0 in the array
-		//so offset effects lookup size
-		curlupsz = curlupsz - curoff;
-		if(curlupsz < 1){
-			curlupsz = 1;
+		//current size calculation, remember that maxidxes are alays size -1
+		cursz = curendpt - curstpt;
+		if(cursz < 1){
+			cursz = 1;
 		};
 
 		if(curphs >= -1 && curphs <= 1 && buf){
 			//if phase if b/w -1 and 1, map and read, else 0
-			//mapping curphs to the realidx where -1 maps to offset and 1 maps to offset + lookupsz - 1
-			//resulting in mappings to lookupsz indices (if offset = 0, and lookupsz = 9, 8 is the maxidx to map to)
+			//mapping curphs to the realidx where -1 maps to stpt and 1 maps to stpt + cursz - 1
+			//resulting in mappings to endpt indices (if stpt = 0, and endpt = 9, 8 is the maxidx to map to)
+			//if curdir is -1, need to flip relation  
 			int realidx; //the real mapped idx in the buffer
-			realidx = curoff + (int)((curphs+1.f) * 0.5f * (curlupsz-1));
+			realidx = curstpt + (int)(((curphs*curdir)+1.f) * 0.5f * (cursz-1));
 
 			//bounds checking
 			if(realidx > maxidx){
@@ -148,7 +195,7 @@ void lookup_tilde_setup(void)
 			     (t_newmethod)lookup_new,
 			     (t_method)lookup_free,
 			     sizeof(t_lookup), 0,
-			     A_DEFSYM, A_DEFFLOAT, A_DEFFLOAT, 0);
+			     A_GIMME, 0);
 
     CLASS_MAINSIGNALIN(lookup_class, t_lookup, x_f);
     class_addmethod(lookup_class, (t_method)lookup_dsp,

--- a/classes/binaries/signal/lookup.c
+++ b/classes/binaries/signal/lookup.c
@@ -15,8 +15,8 @@ typedef struct _lookup
 	t_float x_f; //dummy variable
 	int x_npoints; //arraysize in samples
 
-	t_inlet *x_offlet; //inlet for stpt
-	t_inlet *x_sizelet; //inlet for endpoint
+	t_inlet *x_startlet; //inlet for stpt
+	t_inlet *x_endlet; //inlet for endpoint
 	t_outlet *x_out; //outlet
 } t_lookup;
 
@@ -96,10 +96,10 @@ static void *lookup_new(t_symbol *s, int argc, t_atom *argv){
 	};
 
 	x->x_arrayname = name;
-	x->x_offlet = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-	x->x_sizelet = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-	pd_float((t_pd *)x->x_offlet, stpt);
-	pd_float( (t_pd *)x->x_sizelet, endpt);
+	x->x_startlet = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+	x->x_endlet = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+	pd_float((t_pd *)x->x_startlet, stpt);
+	pd_float( (t_pd *)x->x_endlet, endpt);
 	x->x_out = outlet_new(&x->x_obj, gensym("signal"));
 	
 	return (x);
@@ -182,8 +182,8 @@ static void lookup_dsp(t_lookup *x, t_signal **sp)
 
 static void *lookup_free(t_lookup *x)
 {
-	inlet_free(x->x_offlet);
-	inlet_free(x->x_sizelet);
+	inlet_free(x->x_startlet);
+	inlet_free(x->x_endlet);
 	outlet_free(x->x_out);
 	return (void *)x;
 }


### PR DESCRIPTION
changing variable names to start point and end point (because that's what they really are).

updated to take into account if start point is bigger than end point (then reverse direction).

Also, I changed the setup method to A_GIMME. I was noticing that if I tried to set up the object with [lookup~ 9 0], it would assume that the end point wasn't passed (I think A_DEFFLOAT defaults to 0) so it would hit up the default end point of 512. I believe that's undesired, so the only other way to handle this is to use an A_GIMME method. This obviously makes the new method more complicated in terms of argument parsing, but I think I've got it down.