### PR TITLE
decycling cycle~

### DIFF
--- a/classes/binaries/signal/cycle.c
+++ b/classes/binaries/signal/cycle.c
@@ -12,7 +12,6 @@
 #include <math.h>
 #include <stdlib.h>
 #include "m_pd.h"
-#include "shared.h" // needed?
 
 #define PDCYCYCLE_FREQ 	0
 #define PDCYCYCLE_PHASE 0
@@ -48,11 +47,13 @@ static t_class *cycle_class;
 //making the cosine table
 static double *cycle_makecostab(){
 	int i;
-	double twopi = 2.f * 3.14159265358979;
-	double * costable = malloc(sizeof(double)*COS_TABSIZE);
-	for(i=0; i<COS_TABSIZE; i++){
-		double idx = ((double)i*twopi)/(double)COS_TABSIZE;
-		costable[i] = cos(idx);
+	double twopi = 2.f * M_PI;
+	double stepsize = twopi/((double)COS_TABSIZE);
+	double * costable = malloc(sizeof(double)*(COS_TABSIZE+1));
+	double phase = 0;
+	for(i=0; i<=COS_TABSIZE; i++){
+		costable[i] = cos(phase);
+		phase += stepsize;
 	};
 	return costable;
 }


### PR DESCRIPTION
the title was suspposed to be declicking,.. oops,.. 


well, i declicked cycle~ by adding one more array index than what COS_TABSIZE is,.. which means the array is actually one bigger than COS_TABSIZE but the highest index is exactly that number...... it does seem to work though lol.

I looked at sickle's way of making cosine tables and it looks like, at least to the comments, that the original rounded upwards to the nearest power of two (i think) so he was returning more elements than requested anyways, but then also updating the tabsize.  I'm noticing though that x_usertableini also has an additional index also,...  

Thinking it's how it's wrapping,.. I've actually just increased the stepsize to reflect the new array size,.. so  the phase changes twopi/(COS_TABSIZE+1) each time.... so the last value in the table is actually cos(twopi-1/(COS_TABSIZE+1)) and there's no clicks eitther.... so I'm strongly suspecting it's the way COS_TABSIZE is used in the perform methods... 

i don't have access to good speakers so somebody tell me if one sounds crappier than the other lol. i've plugged both into fiddle~ with a 8192 window size and it doesn't seem to make much of a difference ,.. even in the lower frequencies... 