### PR TITLE
minor cybuf edits, dearsiced/defragilized poke~

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,6 @@ shared/common/vefl.c \
 shared/unstable/fragile.c
     peek~.class.sources := binaries_src/signal/peek.c $(sarsic)
     play~.class.sources := binaries_src/signal/play.c $(sarsic)
-    poke~.class.sources := binaries_src/signal/poke.c $(sarsic) # only using fragile
     record~.class.sources := binaries_src/signal/record.c $(sarsic)
     wave~.class.sources := binaries_src/signal/wave.c $(sarsic)
 
@@ -384,6 +383,7 @@ shared/unstable/fragile.c
 scybuf := shared/cybuf.c
     index~.class.sources := binaries_src/signal/index.c $(scybuf)
     buffir~.class.sources := binaries_src/signal/buffir.c $(scybuf)
+    poke~.class.sources := binaries_src/signal/poke.c $(scybuf) 
 
 #######################################################################
 ### CYCLONE ###     ### CYCLONE ### ### CYCLONE ###     ### CYCLONE ###

--- a/binaries_src/signal/index.c
+++ b/binaries_src/signal/index.c
@@ -90,7 +90,7 @@ static void *index_new(t_symbol *s, t_floatarg f)
     int ch = (f > 0 ? (int)f : 0);
     /* two signals:  index input, value output */
     t_index *x = (t_index *)pd_new(index_class);
-    x->x_cybuf = cybuf_init(x, s, (ch ? INDEX_MAXCHANNELS : 0));
+    x->x_cybuf = cybuf_init((t_class *)x, s, (ch ? INDEX_MAXCHANNELS : 0));
     if (x->x_cybuf){
 	if (ch > INDEX_MAXCHANNELS)
 	    ch = INDEX_MAXCHANNELS;

--- a/binaries_src/signal/poke.c
+++ b/binaries_src/signal/poke.c
@@ -4,16 +4,49 @@
 
 /* LATER: 'click' method */
 
+
+/*dearsic-ing and fragile-ing (plucked the necessary bits from it)
+ 
+  note, the fragile bit was using a way to pluck the float val from a signal
+  ignoring usual float-to-signal conversions, this is found in pd's m_obj.c so 
+  if something breaks wrt to inlet2, look there first
+
+  Derek Kwan 2016
+
+*/
+
 #include "m_pd.h"
-#include "unstable/fragile.h"
-#include "sickle/sic.h"
-#include "sickle/arsic.h"
+#include "cybuf.h"
 
 #define POKE_MAXCHANNELS  4  /* LATER implement arsic resizing feature */
 
+//needed for that one x->x_indexptr, seems like not many objects use fragile anymore so decided
+//to stick it here, plus this is the only one that does this particular thing  - DK
+union inletunion
+{
+    t_symbol *iu_symto;
+    t_gpointer *iu_pointerslot;
+    t_float *iu_floatslot;
+    t_symbol **iu_symslot;
+    t_sample iu_floatsignalvalue;
+};
+
+struct _inlet
+{
+    t_pd i_pd;
+    struct _inlet *i_next;
+    t_object *i_owner;
+    t_pd *i_dest;
+    t_symbol *i_symfrom;
+    union inletunion i_un;
+};
+
+//end extra stuff for x->x_indexptr
+
 typedef struct _poke
 {
-    t_arsic    x_arsic;
+    t_object x_obj;
+    t_cybuf   *x_cybuf;
     int        x_maxchannels;
     int        x_effchannel;  /* effective channel (clipped reqchannel) */
     int        x_reqchannel;  /* requested channel */
@@ -21,20 +54,22 @@ typedef struct _poke
     t_clock   *x_clock;
     double     x_clocklasttick;
     int        x_clockset;
+
+    t_inlet   *x_idxlet;
 } t_poke;
 
 static t_class *poke_class;
 
 static void poke_tick(t_poke *x)
 {
-    arsic_redraw((t_arsic *)x);  /* LATER redraw only dirty channel(s!) */
+    cybuf_redraw(x->x_cybuf);  /* LATER redraw only dirty channel(s!) */
     x->x_clockset = 0;
     x->x_clocklasttick = clock_getlogicaltime();
 }
 
 static void poke_set(t_poke *x, t_symbol *s)
 {
-    arsic_setarray((t_arsic *)x, s, 1);
+    cybuf_setarray(x->x_cybuf, s);
 }
 
 /*
@@ -53,13 +88,14 @@ static void poke_bang(t_poke *x)
    (if not, current index is set to zero).  Incompatible (revisit LATER) */
 static void poke_float(t_poke *x, t_float f)
 {
-    t_arsic *sic = (t_arsic *)x;
+
+    t_cybuf *c = x->x_cybuf;
     t_word *vp;
-    arsic_validate(sic, 0);  /* LATER rethink (efficiency, and complaining) */
-    if (vp = sic->s_vectors[x->x_effchannel])
+    cybuf_validate(c);  /* LATER rethink (efficiency, and complaining) */
+    if (vp = c->c_vectors[x->x_effchannel])
     {
 	int ndx = (int)*x->x_indexptr;
-	if (ndx >= 0 && ndx < sic->s_vecsize)
+	if (ndx >= 0 && ndx < c->c_vecsize)
 	{
 	    double timesince;
 	    vp[ndx].w_float = f;
@@ -84,16 +120,16 @@ static void poke_ft2(t_poke *x, t_floatarg f)
 
 static t_int *poke_perform(t_int *w)
 {
-    t_arsic *sic = (t_arsic *)(w[1]);
+    t_poke *x = (t_poke *)(w[1]);
+    t_cybuf *c = x->x_cybuf;
     int nblock = (int)(w[2]);
     t_float *in1 = (t_float *)(w[3]);
     t_float *in2 = (t_float *)(w[4]);
-    t_poke *x = (t_poke *)sic;
-    t_word *vp = sic->s_vectors[x->x_effchannel];
-    if (vp && sic->s_playable)
+    t_word *vp = c->c_vectors[x->x_effchannel];
+    if (vp && c->c_playable)
     {
-    arsic_redraw((t_arsic *)x);
-	int vecsize = sic->s_vecsize;
+    cybuf_redraw(c);
+	int vecsize = c->c_vecsize;
 	while (nblock--)
 	{
 	    t_float f = *in1++;
@@ -102,28 +138,30 @@ static t_int *poke_perform(t_int *w)
 		vp[ndx].w_float = f;
 	}
     }
-    return (w + sic->s_nperfargs + 1);
+    return (w + 5);
 }
 
 static void poke_dsp(t_poke *x, t_signal **sp)
 {
-    arsic_dsp((t_arsic *)x, sp, poke_perform, 0);
+   // arsic_dsp((t_arsic *)x, sp, poke_perform, 0);
+    dsp_add(poke_perform, 4, x, sp[0]->s_n, sp[0]->s_vec, sp[1]->s_vec);
 }
 
 static void poke_free(t_poke *x)
 {
     if (x->x_clock) clock_free(x->x_clock);
-    arsic_free((t_arsic *)x);
+    inlet_free(x->x_idxlet);
+    cybuf_free(x->x_cybuf);
 }
 
 static void *poke_new(t_symbol *s, t_floatarg f)
 {
     int ch = (f > 0 ? (int)f : 0);
-    t_poke *x = (t_poke *)arsic_new(poke_class, s,
-				    (ch ? POKE_MAXCHANNELS : 0), 2, 0);
+	t_poke *x = (t_poke  *)pd_new(poke_class);
+
+    x->x_cybuf = cybuf_init((t_class *) x, s, (ch ? POKE_MAXCHANNELS : 0));
     if (x)
     {
-	t_inlet *in2;
 	if (ch > POKE_MAXCHANNELS)
 	    ch = POKE_MAXCHANNELS;
 	x->x_maxchannels = (ch ? POKE_MAXCHANNELS : 1);
@@ -131,8 +169,11 @@ static void *poke_new(t_symbol *s, t_floatarg f)
 	/* CHECKED: no float-to-signal conversion.
 	   Floats in 2nd inlet are ignored when dsp is on, but only if a signal
 	   is connected to this inlet.  Incompatible (revisit LATER). */
-	in2 = inlet_new((t_object *)x, (t_pd *)x, &s_signal, &s_signal);
-	x->x_indexptr = fragile_inlet_signalscalar(in2);
+	x->x_idxlet = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+
+        //plucked from old unstable/fragile.c. found in pd's m_obj.c, basically plucks the float value
+        //from the signal witout the float-to-signal conversion, I think... - DK
+	x->x_indexptr = &(x->x_idxlet)->i_un.iu_floatsignalvalue;
 	inlet_new((t_object *)x, (t_pd *)x, &s_float, gensym("ft2"));
 	x->x_clock = clock_new(x, (t_method)poke_tick);
 	x->x_clocklasttick = clock_getlogicaltime();
@@ -148,9 +189,10 @@ void poke_tilde_setup(void)
 			   (t_method)poke_free,
 			   sizeof(t_poke), 0,
 			   A_DEFSYM, A_DEFFLOAT, 0);
-    arsic_setup(poke_class, poke_dsp, poke_float);
-    //class_addbang(poke_class, poke_bang); 
+    class_domainsignalin(poke_class, -1);
     class_addfloat(poke_class, poke_float);
+    //class_addbang(poke_class, poke_bang); 
+    class_addmethod(poke_class, (t_method)poke_dsp, gensym("dsp"), 0);
     class_addmethod(poke_class, (t_method)poke_set,
 		    gensym("set"), A_SYMBOL, 0);
     class_addmethod(poke_class, (t_method)poke_ft2,

--- a/shared/cybuf.c
+++ b/shared/cybuf.c
@@ -207,7 +207,7 @@ void *cybuf_init(t_class *owner, t_symbol *bufname, int numchans){
     return (c);
 }
 
-static void cybuf_enable(t_cybuf *c, t_floatarg f)
+void cybuf_enable(t_cybuf *c, t_floatarg f)
 {
     c->c_disabled = (f == 0);
     cybuf_playcheck(c);

--- a/shared/cybuf.h
+++ b/shared/cybuf.h
@@ -39,10 +39,11 @@ void cybuf_playcheck(t_cybuf *c);
 //int cybuf_getnchannels(t_cybuf *x);
 void cybuf_setarray(t_cybuf *c, t_symbol *name);
 void cybuf_setminsize(t_cybuf *c, int i);
-static void cybuf_enable(t_cybuf *c, t_floatarg f);
+void cybuf_enable(t_cybuf *c, t_floatarg f);
 //void cybuf_dsp(t_cybuf *x, t_signal **sp, t_perfroutine perf, int complain);
 void *cybuf_init(t_class *owner, t_symbol *bufname, int numchans);
 void cybuf_free(t_cybuf *c);
 //void cybuf_setup(t_class *c, void *dspfn, void *floatfn);
+void cybuf_checkdsp(t_cybuf *c);
 
 #endif


### PR DESCRIPTION
dearsiced and defragilized poke,.. well kinda. i just brought in what fragile did, it's the only class that uses the particular method,.. apparently it's a way to ignore float-to-signal conversion, which poke~ needs. since it seems not a lot of classes are using fragile anymore, decided to bring it in. also, fragile is meant for the functionalities pd is likely to break in the future,.. so if something breaks with inlet 2 in the future, i'd look there first.