### PR TITLE
peek~, wave~: dearsic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,7 +372,6 @@ shared/sickle/arsic.c \
 shared/common/loud.c \
 shared/common/vefl.c \
 shared/unstable/fragile.c
-    peek~.class.sources := binaries_src/signal/peek.c $(sarsic)
     play~.class.sources := binaries_src/signal/play.c $(sarsic)
     record~.class.sources := binaries_src/signal/record.c $(sarsic)
     wave~.class.sources := binaries_src/signal/wave.c $(sarsic)
@@ -381,8 +380,9 @@ shared/unstable/fragile.c
 
 #cybuf (aka arsic replacement) classes
 scybuf := shared/cybuf.c
-    index~.class.sources := binaries_src/signal/index.c $(scybuf)
     buffir~.class.sources := binaries_src/signal/buffir.c $(scybuf)
+    index~.class.sources := binaries_src/signal/index.c $(scybuf)
+    peek~.class.sources := binaries_src/signal/peek.c $(scybuf)
     poke~.class.sources := binaries_src/signal/poke.c $(scybuf) 
 
 #######################################################################

--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,6 @@ shared/common/vefl.c \
 shared/unstable/fragile.c
     play~.class.sources := binaries_src/signal/play.c $(sarsic)
     record~.class.sources := binaries_src/signal/record.c $(sarsic)
-    wave~.class.sources := binaries_src/signal/wave.c $(sarsic)
 
 # loud and vefl actually not being used in the classes, but needed for some reason
 
@@ -384,6 +383,7 @@ scybuf := shared/cybuf.c
     index~.class.sources := binaries_src/signal/index.c $(scybuf)
     peek~.class.sources := binaries_src/signal/peek.c $(scybuf)
     poke~.class.sources := binaries_src/signal/poke.c $(scybuf) 
+    wave~.class.sources := binaries_src/signal/wave.c $(scybuf)
 
 #######################################################################
 ### CYCLONE ###     ### CYCLONE ### ### CYCLONE ###     ### CYCLONE ###

--- a/binaries_src/signal/selector.c
+++ b/binaries_src/signal/selector.c
@@ -111,9 +111,15 @@ static void *selector_new(t_symbol *s, int argc, t_atom *argv)
     return (x);
 }
 
+void * selector_free(t_selector *x){
+    
+	 freebytes(x->x_ivecs, x->x_sigputs * sizeof(*x->x_ivecs));
+         return (void *) x;
+}
+
 void selector_tilde_setup(void)
 {
-    selector_class = class_new(gensym("selector~"), (t_newmethod)selector_new, 0,
+    selector_class = class_new(gensym("selector~"), (t_newmethod)selector_new, (t_method)selector_free,
             sizeof(t_selector), CLASS_DEFAULT, A_GIMME, 0);
     class_addmethod(selector_class, (t_method)selector_dsp, gensym("dsp"), A_CANT, 0);
     CLASS_MAINSIGNALIN(selector_class, t_selector, x_state);


### PR DESCRIPTION
dearsiced/cybuffed peek~ and wave~ now.

wave~ took a bit of finagling because of the variable number of outputs. i copied the way i handled passing the t_signal ** sp from the dsp method to the perform method the same way I handled it in selector. basically allocating vectors and each part of t_sig to each allocated vector. 

while, i was digging in selector i noticed a lacking but needed selector_free method so i added it which should help it become not memory-leaky.