### PR TITLE
adding c_len to cybuf, de-erroring wave~/record~

### DIFF
--- a/cyclone_src/binaries/signal/record.c
+++ b/cyclone_src/binaries/signal/record.c
@@ -55,26 +55,30 @@ typedef struct _record
 
 static t_class *record_class;
 
-
+/*
+kept here for legacy, now built into cybuf - DK
 static t_float record_getarraysmp(t_record *x, t_symbol *arrayname){
   t_garray *garray;
+  t_symbol *checkname; //name to check
 	char bufname[MAXPDSTRING];
 	t_float retsmp = -1;
 	int numchan = x->x_numchans;
 	if(numchan > 1){
 		sprintf(bufname, "0-%s", arrayname->s_name);
+                checkname = gensym(bufname);
 	}
 	else{
 		sprintf(bufname, "%s", arrayname->s_name);
+                checkname = arrayname;
 	};
-  if(!(garray = (t_garray *)pd_findbyclass(arrayname,garray_class))) {
+  if(!(garray = (t_garray *)pd_findbyclass(checkname,garray_class))) {
     pd_error(x, "%s: no such table", bufname);
   } else {
    	retsmp = garray_npoints(garray);
   };
 	return retsmp;
 }
-
+*/
 
 static void record_tick(t_record *x)
 {
@@ -387,7 +391,7 @@ static void *record_new(t_symbol *s, int argc, t_atom *argv)
     {
 	
 	x->x_numchans = c->c_numchans;
-	t_float arraysmp = record_getarraysmp(x, arrname);
+	t_float arraysmp = (t_float)c->c_len;
         x->x_ivecs = getbytes(x->x_numchans * sizeof(*x->x_ivecs));
 	if(loopend < 0 && arraysmp > 0){
 //if loopend not set or less than 0 and arraysmp doesn't fail, set it to arraylen in ms

--- a/cyclone_src/binaries/signal/wave.c
+++ b/cyclone_src/binaries/signal/wave.c
@@ -38,7 +38,7 @@ typedef struct _wave
 
 static t_class *wave_class;
 
-
+/* kept here for legacy, now cybuf has c_len
 
 static t_float wave_getarraysmp(t_wave *x, t_symbol *arrayname){
   t_garray *garray;
@@ -61,7 +61,7 @@ static t_float wave_getarraysmp(t_wave *x, t_symbol *arrayname){
 	return retsmp;
 }
 
-
+*/
 
 /* interpolation functions w/ jump table -- code was cleaner than a massive
 switch - case block in the wave_perform() routine; might be very slightly
@@ -607,7 +607,7 @@ static void *wave_new(t_symbol *s, int argc, t_atom * argv){
 	if(endpt < 0){
 		//endpt not passed as art,.. get the array number of samples if set
 		if(nameset){
-			t_float arraysmp = wave_getarraysmp(x, name);
+			t_float arraysmp = x->x_cybuf->c_len;
 			endpt = arraysmp;
 		}
 		else{ //else just set to 0

--- a/shared/cybuf.c
+++ b/shared/cybuf.c
@@ -25,6 +25,7 @@ t_word *cybuf_get(t_cybuf *c, t_symbol * name, int *bufsize, int indsp){
 	    int bufsz;
 	    t_word *vec;
 	    if (garray_getfloatwords(ap, &bufsz, &vec)){
+   	        c->c_len = garray_npoints(ap);
 		if (indsp) garray_usedindsp(ap);
 		if (bufsize) *bufsize = bufsz;
 		return (vec);
@@ -203,6 +204,7 @@ void *cybuf_init(t_class *owner, t_symbol *bufname, int numchans){
     c->c_disabled = 0;
     c->c_playable = 0;
     c->c_minsize = 1;
+    c->c_len = 0;
     cybuf_setarray(c, bufname);
     return (c);
 }

--- a/shared/cybuf.h
+++ b/shared/cybuf.h
@@ -28,6 +28,7 @@ typedef struct _cybuf
     int         c_playable;
     int         c_minsize;
     int         c_disabled;
+    unsigned int    c_len; //number of samples in array
 } t_cybuf;
 
 t_word *cybuf_get(t_cybuf *c, t_symbol * name, int *bufsize, int indsp);


### PR DESCRIPTION
getting rid of the errors in wave~ and record~. well, i fixed getarraysmp in both, but then decided to integrate finding out the number of samples in a table with cybuf_get,.. it sets the number of samples for each channel in a multichannel buffer and i suppose i could make it not do that,.. but i don't think it's that expensive to do this check each time anyways........ this is now set in c_len, which is a member of t_cybuf.

then to get rid of the other errors,.. basically you have to copy, delete, and paste the pertinent cyclone objects. i think they're further up in the saved patch, so they get instantiated before the array does,.. at least that's my theory,.. well, doing that gets rid of the errors anyways. 