### PR TITLE
removing c_len, c_vecsize to c_npts in cybuf

### DIFF
--- a/cyclone_src/binaries/signal/buffir.c
+++ b/cyclone_src/binaries/signal/buffir.c
@@ -72,7 +72,7 @@ static t_int *buffir_perform(t_int *w)
 
 	t_float *oin = (t_float *)(w[4]);
 	t_float *sin = (t_float *)(w[5]);
-	int vecsize = c->c_vecsize;
+	int bufnpts = c->c_npts;
 	t_word *vec = c->c_vectors[0];  /* playable implies nonzero (mono) */
 	while (nblock--)
 	{
@@ -86,8 +86,8 @@ static t_int *buffir_perform(t_int *w)
 		off = 0;
 	    if (npoints > BUFFIR_MAXSIZE)
 		npoints = BUFFIR_MAXSIZE;
-	    if (npoints > vecsize - off)
-		npoints = vecsize - off;
+	    if (npoints > bufnpts - off)
+		npoints = bufnpts - off;
 	    if (npoints > 0)
 	    {
 	    if (!(x->x_checked))
@@ -149,7 +149,7 @@ static void *buffir_new(t_symbol *s, t_floatarg f1, t_floatarg f2)
     /* CHECKME always the first channel used. */
     /* three auxiliary signals: main, offset and size inputs */
     t_buffir *x = (t_buffir *)pd_new(buffir_class);
-    x->x_cybuf = cybuf_init(x, s, 1);
+    x->x_cybuf = cybuf_init((t_class *)x, s, 1);
     if (x->x_cybuf)
     {
 	

--- a/cyclone_src/binaries/signal/index.c
+++ b/cyclone_src/binaries/signal/index.c
@@ -39,7 +39,7 @@ static t_int *index_perform(t_int *w)
     if (c->c_playable)
     {	
 	t_float *xin = (t_float *)(w[3]);
-	int index, maxindex = c->c_vecsize - 1;
+	int index, maxindex = c->c_npts - 1;
 	t_word *vp = c->c_vectors[x->x_effchannel];
 	if (vp)  /* handle array swapping on the fly via ft1 */
 	{

--- a/cyclone_src/binaries/signal/peek.c
+++ b/cyclone_src/binaries/signal/peek.c
@@ -58,7 +58,7 @@ static void peek_float(t_peek *x, t_float f)
     if (vp = c->c_vectors[x->x_effchannel])
     {
 	int ndx = (int)f;
-	if (ndx >= 0 && ndx < c->c_vecsize)
+	if (ndx >= 0 && ndx < c->c_npts)
 	{
 	    if (x->x_pokemode)
 	    {

--- a/cyclone_src/binaries/signal/poke.c
+++ b/cyclone_src/binaries/signal/poke.c
@@ -95,7 +95,7 @@ static void poke_float(t_poke *x, t_float f)
     if (vp = c->c_vectors[x->x_effchannel])
     {
 	int ndx = (int)*x->x_indexptr;
-	if (ndx >= 0 && ndx < c->c_vecsize)
+	if (ndx >= 0 && ndx < c->c_npts)
 	{
 	    double timesince;
 	    vp[ndx].w_float = f;
@@ -129,12 +129,12 @@ static t_int *poke_perform(t_int *w)
     if (vp && c->c_playable)
     {
     cybuf_redraw(c);
-	int vecsize = c->c_vecsize;
+	int npts = c->c_npts;
 	while (nblock--)
 	{
 	    t_float f = *in1++;
 	    int ndx = (int)*in2++;
-	    if (ndx >= 0 && ndx < vecsize)
+	    if (ndx >= 0 && ndx < npts)
 		vp[ndx].w_float = f;
 	}
     }

--- a/cyclone_src/binaries/signal/record.c
+++ b/cyclone_src/binaries/signal/record.c
@@ -114,9 +114,9 @@ static void record_mstoindex(t_record *x)
 		x->x_startindex = 0;  /* CHECKED */
 	};
     x->x_endindex = (int)(x->x_endpoint * x->x_ksr);
-    if (x->x_endindex > c->c_vecsize
+    if (x->x_endindex > c->c_npts
 	|| x->x_endindex <= 0){
-		x->x_endindex = c->c_vecsize;  /* CHECKED (both ways) */
+		x->x_endindex = c->c_npts;  /* CHECKED (both ways) */
 	};
     record_setsync(x);
 }
@@ -195,7 +195,7 @@ static t_int *record_perform(t_int *w)
     float sync = x->x_sync;
     if (c->c_playable && endphase > phase)
     {
-	//int vecsize = c->c_vecsize;
+	//int vecsize = c->c_npts;
 	int ch, over, i, nxfer, ndone = 0;
 loopover:
 	if ((nxfer = endphase - phase) > nblock)
@@ -391,7 +391,7 @@ static void *record_new(t_symbol *s, int argc, t_atom *argv)
     {
 	
 	x->x_numchans = c->c_numchans;
-	t_float arraysmp = (t_float)c->c_len;
+	t_float arraysmp = (t_float)c->c_npts;
         x->x_ivecs = getbytes(x->x_numchans * sizeof(*x->x_ivecs));
 	if(loopend < 0 && arraysmp > 0){
 //if loopend not set or less than 0 and arraysmp doesn't fail, set it to arraylen in ms

--- a/cyclone_src/binaries/signal/wave.c
+++ b/cyclone_src/binaries/signal/wave.c
@@ -38,7 +38,7 @@ typedef struct _wave
 
 static t_class *wave_class;
 
-/* kept here for legacy, now cybuf has c_len
+/* kept here for legacy
 
 static t_float wave_getarraysmp(t_wave *x, t_symbol *arrayname){
   t_garray *garray;
@@ -445,7 +445,7 @@ static t_int *wave_perform(t_int *w)
     if (c->c_playable)
     {	
 		//t_wave *x = (t_wave *)sic;
-		int vecsize = c->c_vecsize;
+		int npts = c->c_npts;
 		float ksr = x->x_ksr;
 		t_word **vectable = c->c_vectors;
 		//t_float *xin = (t_float *)(w[3]);
@@ -454,7 +454,7 @@ static t_int *wave_perform(t_int *w)
                 t_float *xin = x->x_in;
                 t_float *sin = x->x_st;
                 t_float *ein = x->x_e;
-		int maxindex = c->c_vecsize - 1;
+		int maxindex = npts - 1;
 		int interp_mode = x->x_interp_mode;
 		/*Choose interpolation function from jump table. The interpolation functions also
 		  perform the block loop in order not to make a bunch of per-sample decisions.*/	
@@ -607,7 +607,7 @@ static void *wave_new(t_symbol *s, int argc, t_atom * argv){
 	if(endpt < 0){
 		//endpt not passed as art,.. get the array number of samples if set
 		if(nameset){
-			t_float arraysmp = x->x_cybuf->c_len;
+			t_float arraysmp = x->x_cybuf->c_npts;
 			endpt = arraysmp;
 		}
 		else{ //else just set to 0

--- a/shared/cybuf.c
+++ b/shared/cybuf.c
@@ -25,7 +25,7 @@ t_word *cybuf_get(t_cybuf *c, t_symbol * name, int *bufsize, int indsp){
 	    int bufsz;
 	    t_word *vec;
 	    if (garray_getfloatwords(ap, &bufsz, &vec)){
-   	        c->c_len = garray_npoints(ap);
+   	        //c->c_len = garray_npoints(ap);
 		if (indsp) garray_usedindsp(ap);
 		if (bufsize) *bufsize = bufsz;
 		return (vec);
@@ -57,7 +57,7 @@ void cybuf_bug(char *fmt, ...)
 
 void cybuf_clear(t_cybuf *c)
 {
-    c->c_vecsize = 0;
+    c->c_npts = 0;
     memset(c->c_vectors, 0, c->c_numchans * sizeof(*c->c_vectors));
 }
 
@@ -82,25 +82,25 @@ void cybuf_redraw(t_cybuf *c)
 void cybuf_validate(t_cybuf *c)
 {
     cybuf_clear(c);
-    c->c_vecsize = SHARED_INT_MAX;
+    c->c_npts = SHARED_INT_MAX;
     if (c->c_numchans <= 1 && c->c_bufname != &s_)
     {
-	c->c_vectors[0] = cybuf_get(c, c->c_bufname, &c->c_vecsize, 1);
+	c->c_vectors[0] = cybuf_get(c, c->c_bufname, &c->c_npts, 1);
     }
     else if (c->c_numchans > 1){
 	int ch;
 	for (ch = 0; ch < c->c_numchans ; ch++){
-	    int vsz = c->c_vecsize;  /* ignore missing arrays */
+	    int vsz = c->c_npts;  /* ignore missing arrays */
 	    c->c_vectors[ch] =
 		cybuf_get(c, c->c_channames[ch], &vsz, 1);
-	    if (vsz < c->c_vecsize) c->c_vecsize = vsz;
+	    if (vsz < c->c_npts) c->c_npts = vsz;
 	}
     }
-    if (c->c_vecsize == SHARED_INT_MAX) c->c_vecsize = 0;
+    if (c->c_npts == SHARED_INT_MAX) c->c_npts = 0;
 }
 
 void cybuf_playcheck(t_cybuf *c){
-    c->c_playable = (!c->c_disabled && c->c_vecsize >= c->c_minsize);
+    c->c_playable = (!c->c_disabled && c->c_npts >= c->c_minsize);
 }
 
 /*
@@ -198,13 +198,12 @@ void *cybuf_init(t_class *owner, t_symbol *bufname, int numchans){
 	return (0);
     };
     c->c_owner = owner;
-    c->c_vecsize = 0;
+    c->c_npts = 0;
     c->c_vectors = vectors;
     c->c_channames = channames;
     c->c_disabled = 0;
     c->c_playable = 0;
     c->c_minsize = 1;
-    c->c_len = 0;
     cybuf_setarray(c, bufname);
     return (c);
 }

--- a/shared/cybuf.h
+++ b/shared/cybuf.h
@@ -18,7 +18,7 @@ typedef struct _cybuf
 {
     //t_sic       s_sic;
     void     *c_owner; //owner of cybuf, note i don't know if this actually works
-    int         c_vecsize;   /* used also as a validation flag */
+    int         c_npts;   /* used also as a validation flag, number of samples in an array */
     int         c_numchans;
     t_word    **c_vectors;
     t_symbol  **c_channames;
@@ -28,7 +28,6 @@ typedef struct _cybuf
     int         c_playable;
     int         c_minsize;
     int         c_disabled;
-    unsigned int    c_len; //number of samples in array
 } t_cybuf;
 
 t_word *cybuf_get(t_cybuf *c, t_symbol * name, int *bufsize, int indsp);


### PR DESCRIPTION
in my course of writing a little more of the paper, i've finally figured out that c_vecsize is actually the number of samples in the buffer so I got rid of c_len and changed c_vecsize to something more intuitive like c_npts, i've changed every occurence of vecsize to npts (except play~ which i haven't cybuffed yet).

in terms of the paper, i also copied the missing objects so a separate google doc so you can get rid of it in the main paper,.. maybe this list should also be committed to this repo (what do you think)?