### PR TITLE
mousestate: adding mode 1

### DIFF
--- a/cyclone_src/binaries/control/mousestate.c
+++ b/cyclone_src/binaries/control/mousestate.c
@@ -2,26 +2,106 @@
  * For information on usage and redistribution, and for a DISCLAIMER OF ALL
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
+#include <string.h>
 #include "m_pd.h"
 #include "hammer/gui.h"
+#include "g_canvas.h"
+
+//adding mousestate_proxy and related methods
+
+//borrowing IOhannes zmoelnig's receivecanvas_proxy  from iemguts' receivecanvas
+//for gui message interception - DK
+
+//this is the receivecanvas_proxy
+
+
+typedef struct _mousestate_proxy
+{
+    //was going to be in hammer/gui but found it difficult, which is why i chose the g prefix
+    //instead of p as in receivecanvas
+    t_object    g_obj;
+    t_symbol    *g_sym;
+    struct _mousestate      *g_owner; 
+    //copied from the receivecanvas_proxy code
+    //guessing this assures clock is freed indp of parent obj?
+    t_clock     *g_clock;
+
+} t_mousestate_proxy;
+
+static t_class *mousestate_proxy_class;
+
 
 typedef struct _mousestate
 {
     t_object   x_ob;
-    int        x_ispolling;
+    int        x_ispolling02; //polling in mode 0 or mode 2
+    int        x_ispolling1; //polling in mode 1, since it's handled differently for now at least
     int        x_wasbanged;
     int        x_waszeroed;
     int        x_hlast;
     int        x_vlast;
     int        x_hzero;
     int        x_vzero;
+    int        x_mode; //0-screen, 1-object window, 2-active window
     t_outlet  *x_hposout;
     t_outlet  *x_vposout;
     t_outlet  *x_hdiffout;
     t_outlet  *x_vdiffout;
+
+    t_mousestate_proxy *x_icpt;
 } t_mousestate;
 
 static t_class *mousestate_class;
+
+
+
+//mousestate_proxy methods, again lifted from IOhannes Zmoelnig's receivecanvas from iemguts
+
+
+static void mousestate_proxy_actualfree(t_mousestate_proxy *g){
+
+    //in receivecanvas_proxy, the actual free method, fitured this makes it a little easier
+    if(g->g_sym){
+        pd_unbind(&g->g_obj.ob_pd, g->g_sym);
+    };
+    g->g_sym = NULL;
+
+    clock_free(g->g_clock);
+    g->g_clock = NULL;
+
+    g->g_owner = NULL;
+    pd_free(&g->g_obj.ob_pd);
+    g = NULL;
+}
+
+
+
+static t_mousestate_proxy * mousestate_proxy_new(t_mousestate * owner, t_symbol *s){
+    t_mousestate_proxy *g = NULL;
+    
+    if(!owner){
+        return g;
+    };
+    g = (t_mousestate_proxy *)pd_new(mousestate_proxy_class);
+
+    g->g_owner = owner;
+    g->g_sym = s;
+
+    if(g->g_sym){
+        pd_bind(&g->g_obj.ob_pd, g->g_sym);
+    };
+   
+    g->g_clock = clock_new(g, (t_method)mousestate_proxy_actualfree);
+
+    return g;
+}
+
+static void mousestate_proxy_free(t_mousestate_proxy *g){
+    //clock_delay called directly in receivecanvas, figured this makes it a little more transparent
+    clock_delay(g->g_clock, 0);
+}
+
+//========MOUSESTATE_METHODS
 
 static void mousestate_anything(t_mousestate *x,
 				t_symbol *s, int ac, t_atom *av)
@@ -35,9 +115,10 @@ static void mousestate_doup(t_mousestate *x, t_floatarg f)
     outlet_float(((t_object *)x)->ob_outlet, ((int)f ? 0 : 1));
 }
 
+
 static void mousestate_dobang(t_mousestate *x, t_floatarg f1, t_floatarg f2)
 {
-    if (x->x_wasbanged)
+    if (x->x_wasbanged || x->x_ispolling1)
     {
 	int h = (int)f1, v = (int)f2;
 	outlet_float(x->x_vdiffout, v - x->x_vlast);
@@ -49,6 +130,28 @@ static void mousestate_dobang(t_mousestate *x, t_floatarg f1, t_floatarg f2)
 	x->x_wasbanged = 0;
     }
 }
+
+static void mousestate_objwin(t_mousestate *x, int argc, t_atom * argv){
+    t_float objx, objy;
+    if(argc >=2 && x->x_mode == 1){
+        objx = atom_getfloatarg(0, argc, argv);
+        objy = atom_getfloatarg(1, argc, argv);
+        mousestate_dobang(x, objx, objy); 
+    };
+}
+
+//================= MOUSESTATE_PROXY_METHOD
+void mousestate_proxy_anything(t_mousestate_proxy *g, t_symbol *s, int argc, t_atom *argv){
+    if(g->g_owner){
+        //unlike receivecanvas, filter out only motion messages
+        if(strcmp(s->s_name, "motion") == 0){
+            mousestate_objwin(g->g_owner, argc, argv);
+            };
+    };
+    
+}
+
+//================= BACK TO MOUSESTATE
 
 static void mousestate_dozero(t_mousestate *x, t_floatarg f1, t_floatarg f2)
 {
@@ -63,7 +166,7 @@ static void mousestate_dozero(t_mousestate *x, t_floatarg f1, t_floatarg f2)
 
 static void mousestate_dopoll(t_mousestate *x, t_floatarg f1, t_floatarg f2)
 {
-    if (x->x_ispolling)
+    if (x->x_ispolling02)
     {
 	x->x_wasbanged = 1;
 	mousestate_dobang(x, f1, f2);
@@ -72,31 +175,66 @@ static void mousestate_dopoll(t_mousestate *x, t_floatarg f1, t_floatarg f2)
 
 static void mousestate_bang(t_mousestate *x)
 {
-    hammergui_mousexy(gensym("_bang"));
+    switch(x->x_mode){
+        case 0:
+            hammergui_screenmousexy(gensym("_bang"));
+            break;
+        case 1:
+            break;
+        case 2:
+            hammergui_focusmousexy(gensym("_bang"));
+            break;
+        default:
+            break;
+    };
     x->x_wasbanged = 1;
 }
 
 static void mousestate_poll(t_mousestate *x)
 {
-    if (!x->x_ispolling)
-    {
-	x->x_ispolling = 1;
-	hammergui_startpolling((t_pd *)x);
+    int mode = x->x_mode;
+    if(mode != 1){
+        if (!x->x_ispolling02)
+        {
+            x->x_ispolling02 = 1;
+                hammergui_startpolling((t_pd *)x);
+
+        };
     }
+    else{
+        x->x_ispolling1 = 1;
+    };
 }
 
 static void mousestate_nopoll(t_mousestate *x)
 {
-    if (x->x_ispolling)
-    {
-	x->x_ispolling = 0;
-	hammergui_stoppolling((t_pd *)x);
+    int mode = x->x_mode;
+    if(mode != 1){
+        if (x->x_ispolling02)
+        {
+            x->x_ispolling02 = 0;
+            hammergui_stoppolling((t_pd *)x);
+        }
     }
+    else{
+        x->x_ispolling1 = 0;
+    };
 }
 
 static void mousestate_zero(t_mousestate *x)
 {
-    hammergui_mousexy(gensym("_zero"));
+    switch(x->x_mode){
+        case 0:
+            hammergui_screenmousexy(gensym("_zero"));
+            break;
+        case 1:
+            break;
+        case 2:
+            hammergui_focusmousexy(gensym("_zero"));
+            break;
+        default:
+            break;
+    };
     x->x_waszeroed = 1;
 }
 
@@ -109,20 +247,59 @@ static void mousestate_free(t_mousestate *x)
 {
     mousestate_nopoll(x);
     hammergui_unbindmouse((t_pd *)x);
+    mousestate_proxy_free(x->x_icpt);
+}
+
+static void mousestate_mode(t_mousestate *x, t_floatarg f){
+    int mode = (int) f;
+    if(mode < 0){
+        mode = 0;
+    }
+    else if(mode > 2){
+        mode = 2;
+    };
+
+    //must take care of polling if switching b/w mode 1 and any other mode (and vice versa)
+    if(
+        (mode == 1 && x->x_ispolling02 && x->x_mode != 1) ||
+      (mode != 1 && x->x_ispolling1 && x->x_mode == 1)
+            ){
+        mousestate_nopoll(x);
+        x->x_mode = mode;
+        mousestate_poll(x);
+    }
+    else{
+        x->x_mode = mode;
+    };
 }
 
 static void *mousestate_new(void)
 {
     t_mousestate *x = (t_mousestate *)pd_new(mousestate_class);
-    x->x_ispolling = x->x_wasbanged = x->x_waszeroed = 0;
+    x->x_ispolling02 = x->x_wasbanged = x->x_waszeroed = 0;
+    x->x_ispolling1 = 0;
     outlet_new((t_object *)x, &s_float);
     x->x_hposout = outlet_new((t_object *)x, &s_float);
     x->x_vposout = outlet_new((t_object *)x, &s_float);
     x->x_hdiffout = outlet_new((t_object *)x, &s_float);
     x->x_vdiffout = outlet_new((t_object *)x, &s_float);
+    x->x_mode = 0;
     hammergui_bindmouse((t_pd *)x);
     hammergui_willpoll();
     mousestate_reset(x);
+
+    //now dealing with mousestate_proxy
+    //mostly copied from iemguts receivecanvas except for depth and new function pointer
+   t_glist *glist=(t_glist *)canvas_getcurrent();
+   t_canvas *canvas=(t_canvas*)glist_getcanvas(glist);
+
+   x->x_icpt = NULL;
+    if(canvas) {
+            char buf[MAXPDSTRING];
+            snprintf(buf, MAXPDSTRING-1, ".x%lx", (t_int)canvas);
+            buf[MAXPDSTRING-1]=0;
+            x->x_icpt=mousestate_proxy_new(x, gensym(buf));
+    }
     return (x);
 }
 
@@ -132,6 +309,9 @@ void mousestate_setup(void)
 				 (t_newmethod)mousestate_new,
 				 (t_method)mousestate_free,
 				 sizeof(t_mousestate), 0, 0);
+    mousestate_proxy_class = class_new(0, 0, 0, sizeof(t_mousestate_proxy), CLASS_NOINLET | CLASS_PD, 0);
+
+    class_addanything(mousestate_proxy_class, mousestate_proxy_anything);
     class_addcreator((t_newmethod)mousestate_new, gensym("MouseState"), 0, 0);
     class_addcreator((t_newmethod)mousestate_new, gensym("cyclone/MouseState"), 0, 0);
     class_addanything(mousestate_class, mousestate_anything);
@@ -152,6 +332,8 @@ void mousestate_setup(void)
 		    gensym("zero"), 0);
     class_addmethod(mousestate_class, (t_method)mousestate_reset,
 		    gensym("reset"), 0);
+    class_addmethod(mousestate_class, (t_method)mousestate_mode,
+		    gensym("mode"), A_FLOAT, 0);
 }
 
 void MouseState_setup(void)

--- a/shared/hammer/gui.c
+++ b/shared/hammer/gui.c
@@ -8,6 +8,15 @@
    (event bindings are local only in tk8.4, and there is no other call
    to XQueryPointer() but from winfo pointer). */
 
+
+//some notes on my working through this:
+//basically we bind the sink to the symbol assoc with hashhammergui #hammergui
+//we bind virtual events <<hammer*>> with actual events like <focus> via event add
+//then we bind these virtual events <<hammer*>> with messages back to pd via pdsend 
+//
+//bindmouse = mouse clicks
+//-DK
+
 #include <stdio.h>
 #include <string.h>
 #include "m_pd.h"
@@ -290,11 +299,21 @@ static int hammergui_setup(void)
     sys_gui(" pdsend {#hammergui _remouse}\n");
     sys_gui("}\n");
 
-    sys_gui("proc hammergui_mousexy {target} {\n");
+    sys_gui("proc hammergui_focusmousexy {target} {\n");
+    sys_gui(" set x [winfo rootx $::focused_window]\n");
+    sys_gui(" set y [winfo rooty $::focused_window]\n");
+    sys_gui(" pdsend \"#hammermouse $target $x $y\"\n");
+    //sys_gui(" ::pdwindow::post $::focused_window\n");
+    sys_gui("}\n");
+
+
+    sys_gui("proc hammergui_screenmousexy {target} {\n");
     sys_gui(" set x [winfo pointerx .]\n");
-    sys_gui(" set y [winfo pointery .]\n");
+    sys_gui(" set y [winfo pointery . ]\n");
     sys_gui(" pdsend \"#hammermouse $target $x $y\"\n");
     sys_gui("}\n");
+
+
 
     /* visibility hack for msw, LATER rethink */
     sys_gui("global hammergui_ispolling\n");
@@ -452,10 +471,17 @@ void hammergui_unbindmouse(t_pd *master)
     else bug("hammergui_unbindmouse");
 }
 
-void hammergui_mousexy(t_symbol *s)
+void hammergui_screenmousexy(t_symbol *s)
 {
     if (hammergui_validate(0))
-	sys_vgui("hammergui_mousexy %s\n", s->s_name);
+	sys_vgui("hammergui_screenmousexy %s\n", s->s_name);
+}
+
+
+void hammergui_focusmousexy(t_symbol *s)
+{
+    if (hammergui_validate(0))
+	sys_vgui("hammergui_focusmousexy %s\n", s->s_name);
 }
 
 void hammergui_willpoll(void)
@@ -540,3 +566,4 @@ void hammergui_unbindvised(t_pd *master)
     }
     else bug("hammergui_unbindvised");
 }
+

--- a/shared/hammer/gui.h
+++ b/shared/hammer/gui.h
@@ -2,6 +2,7 @@
  * For information on usage and redistribution, and for a DISCLAIMER OF ALL
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
+
 #ifndef __HAMMERGUI_H__
 #define __HAMMERGUI_H__
 
@@ -18,7 +19,8 @@ typedef struct _hammergui
 
 void hammergui_bindmouse(t_pd *master);
 void hammergui_unbindmouse(t_pd *master);
-void hammergui_mousexy(t_symbol *s);
+void hammergui_screenmousexy(t_symbol *s);
+void hammergui_focusmousexy(t_symbol *s);
 void hammergui_willpoll(void);
 void hammergui_startpolling(t_pd *master);
 void hammergui_stoppolling(t_pd *master);
@@ -26,5 +28,4 @@ void hammergui_bindfocus(t_pd *master);
 void hammergui_unbindfocus(t_pd *master);
 void hammergui_bindvised(t_pd *master);
 void hammergui_unbindvised(t_pd *master);
-
 #endif


### PR DESCRIPTION
mode 1 is basically lifted from receivecanvas from iohannes zmoelnig's iemguts with minor changes to filter out only motion messages. was originally going to stuck it all in hammer/gui, but that proved,.. complicated, so it's all in mousestate. might want to abstract it out in the future we want other objects to be able to use it.

since it's going about the issue in a diff way than mode 0 and 2, have to handle it in a diff way (so now there are two polling variable members for mousecanvas). it's dirty and complicated and i'm not proud of it, but it works =).

the framework for mode 2 is present in hammer/gui,.. but only returns the top-left corner of the active window for now. also polling is broken for mode 2 because mousestate was originally going to poll for mode 0, so right now if you select poll in mode 2, it defaults to mode 0. i will come back to mode 2 at a later date, i know a hacky way to do it, but I wanna figure out a better way. going to look at the pdtk_canvas_motion method() more like iohannes suggested.

also for right now, mode 1 is always on and running in the background so mousestate is maybe more resource intensive than before,.. maybe there's a way to disable it when not in use in the future (although possibly doubtful since it's basically binding the canvas to the object class so it's receiving all the communication tcl does with the pd canvas).