### PR TITLE
new cybuf single channel mode, adapt peek~

### DIFF
--- a/cyclone_src/binaries/signal/buffir.c
+++ b/cyclone_src/binaries/signal/buffir.c
@@ -149,7 +149,7 @@ static void *buffir_new(t_symbol *s, t_floatarg f1, t_floatarg f2)
     /* CHECKME always the first channel used. */
     /* three auxiliary signals: main, offset and size inputs */
     t_buffir *x = (t_buffir *)pd_new(buffir_class);
-    x->x_cybuf = cybuf_init((t_class *)x, s, 1);
+    x->x_cybuf = cybuf_init((t_class *)x, s, 1, 0);
     if (x->x_cybuf)
     {
 	

--- a/cyclone_src/binaries/signal/index.c
+++ b/cyclone_src/binaries/signal/index.c
@@ -89,7 +89,7 @@ static void *index_new(t_symbol *s, t_floatarg f)
     int ch = (f > 0 ? (int)f : 0);
     /* two signals:  index input, value output */
     t_index *x = (t_index *)pd_new(index_class);
-    x->x_cybuf = cybuf_init((t_class *)x, s, (ch ? INDEX_MAXCHANNELS : 0));
+    x->x_cybuf = cybuf_init((t_class *)x, s, (ch ? INDEX_MAXCHANNELS : 0), 0);
     if (x->x_cybuf){
 	if (ch > INDEX_MAXCHANNELS)
 	    ch = INDEX_MAXCHANNELS;

--- a/cyclone_src/binaries/signal/play.c
+++ b/cyclone_src/binaries/signal/play.c
@@ -655,7 +655,7 @@ static void *play_new(t_symbol * s, int argc, t_atom * argv)
     x->x_pdksr = (float)sys_getsr() * 0.001;
     //set sample rate of array as pd's sample rate for now
     x->x_aksr = x->x_pdksr;
-    x->x_cybuf = cybuf_init((t_class *)x, arrname, chn_n == 3 ? 2 : chn_n);
+    x->x_cybuf = cybuf_init((t_class *)x, arrname, chn_n == 3 ? 2 : chn_n, 0);
     t_cybuf * c = x->x_cybuf;
     
     if (c)

--- a/cyclone_src/binaries/signal/poke.c
+++ b/cyclone_src/binaries/signal/poke.c
@@ -178,7 +178,7 @@ static void *poke_new(t_symbol *s, t_floatarg f)
     int ch = (f > 0 ? (int)f : 0);
 	t_poke *x = (t_poke  *)pd_new(poke_class);
 
-    x->x_cybuf = cybuf_init((t_class *) x, s, (ch ? POKE_MAXCHANNELS : 0));
+    x->x_cybuf = cybuf_init((t_class *) x, s, (ch ? POKE_MAXCHANNELS : 0), 0);
     if (x)
     {
 	if (ch > POKE_MAXCHANNELS)

--- a/cyclone_src/binaries/signal/record.c
+++ b/cyclone_src/binaries/signal/record.c
@@ -461,7 +461,7 @@ static void *record_new(t_symbol *s, int argc, t_atom *argv)
     t_record *x = (t_record *)pd_new(record_class);
     x->x_ksr = (float)sys_getsr() * 0.001;
 
-    x->x_cybuf = cybuf_init((t_class *)x, arrname, chn_n);
+    x->x_cybuf = cybuf_init((t_class *)x, arrname, chn_n, 0);
     t_cybuf * c = x->x_cybuf;
     
     

--- a/cyclone_src/binaries/signal/wave.c
+++ b/cyclone_src/binaries/signal/wave.c
@@ -549,7 +549,7 @@ static void *wave_new(t_symbol *s, int argc, t_atom * argv){
 	};
 
         t_wave *x = (t_wave *)pd_new(wave_class);
-        x->x_cybuf = cybuf_init((t_class *)x, name, numouts);
+        x->x_cybuf = cybuf_init((t_class *)x, name, numouts, 0);
         x->x_numouts = numouts;
 	
         //allocating output vectors

--- a/shared/cybuf.h
+++ b/shared/cybuf.h
@@ -30,6 +30,9 @@ typedef struct _cybuf
     int         c_playable;
     int         c_minsize;
     int         c_disabled;
+    int         c_single; //flag for single channel mode
+                        //0-regular mode, 1-load this particular channel (1-idx)
+                        //should be used with c_numchans == 1
 } t_cybuf;
 
 void cybuf_bug(char *fmt, ...);
@@ -52,10 +55,11 @@ void cybuf_setminsize(t_cybuf *c, int i);
 void cybuf_enable(t_cybuf *c, t_floatarg f);
 //void cybuf_dsp(t_cybuf *x, t_signal **sp, t_perfroutine perf, int complain);
 
-void *cybuf_init(t_class *owner, t_symbol *bufname, int numchans);
+//single channel mode used for poke~/peek~
+void *cybuf_init(t_class *owner, t_symbol *bufname, int numchans, int singlemode);
 void cybuf_free(t_cybuf *c);
 //void cybuf_setup(t_class *c, void *dspfn, void *floatfn);
 void cybuf_checkdsp(t_cybuf *c);
-t_word *cybuf_getchannel(t_cybuf *c, int chan_num);
+void cybuf_getchannel(t_cybuf *c, int chan_num, int complain);
 
 #endif


### PR DESCRIPTION
added the new cybuf single channel mode, changing up the cybuf_validate, cybuf_redraw, and cybuf_init methods. since cybuf_init takes an extra argt for single channel mode now, had to edit every cybuf object to pass it. everything seems to compile and hopefully nothing broke... 

adapted peek~ to use this new single channel mode. if no channel argt is passed, it defaults to the first channel 1 (assuming 1-indexed?). I think it used to be able to default to 0? so i dunno if this changes default behavior.  i guess up next is poke~?