### PR TITLE
funbuff:yval to ints, undo, delouded/vefled, funbuff_set to not clear

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,14 +226,11 @@ htree := \
 shared/hammer/tree.c \
 shared/common/loud.c
 
-htreefilevefl := \
+htreefile := \
 shared/hammer/tree.c \
 shared/hammer/file.c \
-shared/common/vefl.c \
-shared/common/loud.c \
 shared/common/os.c \
-shared/unstable/forky.c \
-shared/unstable/fragile.c
+shared/unstable/forky.c 
 
 splainnotilde := \
 shared/common/loud.c \
@@ -309,7 +306,7 @@ seq.class.sources := cyclone_src/binaries/control/seq.c $(hseq)
 
 offer.class.sources := cyclone_src/binaries/control/offer.c $(htree)
 
-funbuff.class.sources := cyclone_src/binaries/control/funbuff.c $(htreefilevefl)
+funbuff.class.sources := cyclone_src/binaries/control/funbuff.c $(htreefile)
 
 # Signal classes: #################################################################
 


### PR DESCRIPTION
- getting rid out loud/vefl dependencies. also fragile but not sure where that one came from, if there's issues, put fragile back. changes reflected in makefile. i think this might be the last vefl dependency so maybe we can retire vefl.c/h now.

- yvals are now typecast to int (then back to t_float for use in hammertrees and lists)

- undo implemented

- funbuff_set now doesn't clear old contents

- got rid of the funbuff_reduce placeholder