### PR TITLE
cycle~: cybuf, phase inlet overwriting

### DIFF
--- a/cyclone_src/binaries/signal/cycle.c
+++ b/cyclone_src/binaries/signal/cycle.c
@@ -12,6 +12,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include "m_pd.h"
+#include "cybuf.h"
 
 #define PDCYCYCLE_FREQ 	0
 #define PDCYCYCLE_PHASE 0
@@ -27,15 +28,12 @@ typedef struct _cycle
 	t_float	   x_init_phase;
     double     x_phase;
     double     x_conv;
-    t_symbol  *x_name;
     int        x_offset;
     int        x_cycle_tabsize; //how far to loop
-    int		   x_use_all;
-    t_float   *x_table;
+    int		x_use_all;
     double    *x_costable;
-    t_float   *x_usertable;
-    t_float    x_usertableini[PDCYCYCLE_TABSIZE + 1];
-    int        x_usertable_tabsize; // actual table size -- loop size might be smaller
+    t_cybuf    *x_cybuf;
+    int        x_nameset; //if nameset, use cybuf else use costable
 
 	t_inlet    *x_phaselet;
 	t_outlet   *x_outlet;
@@ -112,133 +110,6 @@ static double *cycle_makecostab(t_cycle *x){
 }
 
 
-static t_word *cycle_fetcharray(t_cycle * x, int * tabsz, int indsp){
-	//modifying old vefl_get a bit - DXK
-	t_symbol * name = x->x_name;
-	if (name && name != &s_){
-		t_garray *ap = (t_garray *)pd_findbyclass(name, garray_class);
-	if (ap){
-			int tabsize;
-			t_word *vec;
-			if (garray_getfloatwords(ap, &tabsize, &vec)){
-				if (indsp)
-				{
-					garray_usedindsp(ap);
-				}
-				if (tabsz)
-				{
-					*tabsz = tabsize;
-				}
-				return (vec);
-			}
-			else 
-			{ /* always complain */
-				pd_error(x, "bad template of array '%s'", name->s_name);
-			}
-		}
-		else if (x)
-		{
-			pd_error(x, "no such array '%s'", name->s_name);
-		}
-	}
-	return (0);
-
-}
-
-static void cycle_gettable(t_cycle *x)
-{   
-    x->x_table = 0;
-    int cycle_tabsize = x->x_cycle_tabsize;
-    t_word *table = 0;
-    int tabsize;
-    
-    if (x->x_name){	
-		table = cycle_fetcharray(x, &tabsize, 1);
-	};
-		
-	/* CHECKED buffer is copied */
-	if (table)
-    {
-    	if (x->x_use_all) cycle_tabsize = x->x_cycle_tabsize = tabsize;
-    	int usertable_tabsize = x->x_usertable_tabsize;
-	    int tablePtr, oldbytes;
-	    int samplesFromTable = tabsize - x->x_offset;
-	    int samplesToCopy = samplesFromTable < cycle_tabsize ?
-		samplesFromTable : cycle_tabsize;
-		
-		/*  If requested cycle buffer size is larger than currently allocated,
-			then resize the buffer, or if we're still using the builtin,
-			get a new buffer on the heap. */
-		if (cycle_tabsize > usertable_tabsize)
-		{
-			oldbytes = (usertable_tabsize + 1) * sizeof(*x->x_table);
-			usertable_tabsize = x->x_usertable_tabsize = x->x_cycle_tabsize;
-			if (x->x_usertable == x->x_usertableini)
-			{
-				if(!(x->x_usertable =
-					getbytes((usertable_tabsize + 1) * sizeof(*x->x_usertable))))
-				{
-					x->x_usertable = x->x_usertableini;
-					x->x_cycle_tabsize = x->x_usertable_tabsize = PDCYCYCLE_TABSIZE;
-					pd_error(x,"unable to resize buffer; using size %d",PDCYCYCLE_TABSIZE);
-				}
-				else
-				{
-					//post("getting new table of size %d", cycle_tabsize);
-					x->x_usertable_tabsize = cycle_tabsize;
-				}
-			}
-			else
-			{
-				t_float *tmp;
-				if(!(tmp =
-					resizebytes(x->x_usertable, oldbytes,
-						(usertable_tabsize + 1) * sizeof(*x->x_usertable))))
-				{
-					freebytes(x->x_usertable, oldbytes);
-					x->x_usertable = x->x_usertableini;
-					x->x_cycle_tabsize = x->x_usertable_tabsize = PDCYCYCLE_TABSIZE;
-					pd_error(x,"unable to resize buffer; using size %d",PDCYCYCLE_TABSIZE);
-				}
-				else
-				{
-					x->x_usertable = tmp;
-					x->x_usertable_tabsize = x->x_cycle_tabsize;
-				}
-			}
-		}
-	    // copy the internal table from the external one as far as 
-	    // its size permits and fill the rest with zeroes.
-	    for (tablePtr = 0; tablePtr < cycle_tabsize; tablePtr++)
-	    {
-		if (samplesToCopy > 0) 
-		{
-		    x->x_usertable[tablePtr] = 
-			table[tablePtr + x->x_offset].w_float;
-		    samplesToCopy--;
-		}
-		else 
-		{
-		    x->x_usertable[tablePtr] = 0;
-		}
-	    }
-	    x->x_usertable[tablePtr] = (samplesFromTable > 0) ?
-		table[x->x_offset].w_float : 0;
-
-	    x->x_table = x->x_usertable;
-	    /* CHECKED else no complaint */
-	}
-    else 
-    {
-    	if (x->x_name)
-    	{
-			pd_error(x, "using cosine table");
-    	}
-    	x->x_name = 0;
-    	x->x_cycle_tabsize = COS_TABSIZE;
-    }
-}
-
 static void cycle_set(t_cycle *x, t_symbol *s, t_floatarg f)
 {
 	x->x_use_all = 0;
@@ -246,29 +117,34 @@ static void cycle_set(t_cycle *x, t_symbol *s, t_floatarg f)
 	x->x_cycle_tabsize = PDCYCYCLE_TABSIZE;
     if (s && s != &s_)
     {
-	x->x_name = s;
-	if ((x->x_offset = (int)f) < 0)
-	    x->x_offset = 0;
+    	cybuf_setarray(x->x_cybuf, s);
+	x->x_nameset = 1;
+	x->x_offset = f < 0 ? 0 : (int)f;
     }
-    else x->x_name = 0;
-    cycle_gettable(x);
+    else{
+        x->x_nameset = 0;
+        pd_error(x, "using cosine table");
+    };
 }
 
 static void cycle_setall(t_cycle *x, t_symbol *s)
 {
 	x->x_use_all = 1;
 	x->x_offset = 0;
-    if (s && s != &s_)
-		x->x_name = s;
-    else x->x_name = 0;
-    cycle_gettable(x);
+    if (s && s != &s_){
+	cybuf_setarray(x->x_cybuf, s);
+	x->x_nameset = 1;
+	x->x_cycle_tabsize = x->x_cybuf->c_npts;
+	}
+    else{
+        x->x_nameset = 0;
+        pd_error(x, "using cosine table");
+    };
 }
 
 static void cycle_buffer_offset(t_cycle *x, t_floatarg f)
 {
-    if ((x->x_offset = (int)f) < 0)
-    x->x_offset = 0;
-    cycle_gettable(x);
+    x->x_offset = f < 0 ? 0 : (int) f;
 }
 
 
@@ -299,7 +175,6 @@ static void cycle_buffer_sizeinsamps(t_cycle *x, t_floatarg f)
 {
 
 	cycle_set_buffersize(x, f);
-	cycle_gettable(x);
 }
 
 static void cycle_frequency(t_cycle *x, t_floatarg f)
@@ -316,11 +191,12 @@ static void cycle_phase(t_cycle *x, t_floatarg f)
 static t_int *cycle_perform(t_int *w)
 {
 	t_cycle *x = (t_cycle *)(w[1]);
+	t_cybuf * c = x->x_cybuf;
 	int nblock = (int)(w[2]);
 	t_float *in1 = (t_float *)(w[3]);
 	t_float *in2 = (t_float *)(w[4]);
 	t_float *out = (t_float *)(w[5]);
-	t_float *tab = x->x_table;
+	t_word *tab = c->c_vectors[0];
 	double  *costab = x->x_costable;
 	double dphase = x->x_phase;
 	double conv = x->x_conv;
@@ -329,12 +205,14 @@ static t_int *cycle_perform(t_int *w)
 	double df1, df2;
 	int intphase, index;
 	int cycle_tabsize = x->x_cycle_tabsize;
-	
+	int offset = x->x_offset;
+	int npts = c->c_npts;
+	int usetable = x->x_nameset > 0 && c->c_playable; //use user table	
 	while (nblock--)
 	{
 		freq = *in1++;
 		phasein = *in2++;
-		wrapphase = dphase + phasein;
+                wrapphase = dphase + phasein;
 		if (wrapphase>=1.) 
 		{
 			intphase = (int)wrapphase;
@@ -346,15 +224,20 @@ static t_int *cycle_perform(t_int *w)
 			intphase--;
 			wrapphase -= intphase;
 		}
-		
-		tabphase = wrapphase * cycle_tabsize;
+		if(usetable){	
+			tabphase = wrapphase * cycle_tabsize;
+		}
+		else{
+			tabphase = wrapphase * COS_TABSIZE;
+		};
 		index = (int)tabphase;
 		frac = tabphase - index;
-		if (x->x_name)
+		if (usetable)
 		{
-			f1 = tab[index++];
-			f2 = tab[index];
-			*out++ = f1 + frac * (f2 - f1);
+			f1 = (offset + index) >= npts ? 0. : tab[offset + index].w_float;
+			index++;
+			f2 = (offset + index) >= npts ? 0. : tab[offset + index].w_float;
+			*out++ = (t_float)(f1 + frac * (f2 - f1));
 		}
 		else
 		{
@@ -363,6 +246,8 @@ static t_int *cycle_perform(t_int *w)
 			*out++ = (t_float) (df1 + frac * (df2 - df1));
 		}
 		dphase += freq * conv ;
+                //overwrite phase arg
+                pd_float((t_pd *)x->x_phaselet, phasein);
 	}
 	
 	if (dphase>=1.)
@@ -382,7 +267,7 @@ static t_int *cycle_perform(t_int *w)
 	
 static void cycle_dsp(t_cycle *x, t_signal **sp)
 {
-    cycle_gettable(x);
+    cybuf_checkdsp(x->x_cybuf); 
     x->x_conv = 1.0 / sp[0]->s_sr;
     x->x_phase = x->x_init_phase;
     pd_float((t_pd *)x->x_phaselet, 0.);
@@ -395,7 +280,7 @@ static void *cycle_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_cycle *x = (t_cycle *)pd_new(cycle_class);
     
-	t_symbol * name;
+	t_symbol * name = NULL;
 	t_float phase, freq, offset, bufsz;
 
 	phase = PDCYCYCLE_PHASE;
@@ -403,7 +288,6 @@ static void *cycle_new(t_symbol *s, int argc, t_atom *argv)
 	offset = PDCYCYCLE_OFFSET;
 	bufsz = PDCYCYCLE_TABSIZE;
 	int argnum = 0;
-	int anamedef = 0; //flag if array name is defined
 	int pastargs = 0; //flag if attributes are specified, then don't accept array name anymore
 	int bufferattrib = 0; //flag if @buffer attribute is set; needs to default to whole buffer
 	int buffersizeattrib = 0; // flag if @buffer_sizeinsamps attribute is set
@@ -435,7 +319,6 @@ static void *cycle_new(t_symbol *s, int argc, t_atom *argv)
 						name = atom_getsymbolarg(1, argc, argv);
 						argc-=2;
 						argv+=2;
-						anamedef = 1;
 						pastargs = 1;
 						bufferattrib = 1;
 					}
@@ -497,7 +380,6 @@ static void *cycle_new(t_symbol *s, int argc, t_atom *argv)
 					name = curarg;
 					argc--;
 					argv++;
-					anamedef = 1;
 			}
 			else{
 				goto errstate;
@@ -509,22 +391,15 @@ static void *cycle_new(t_symbol *s, int argc, t_atom *argv)
 	};
 
     x->x_costable = cycle_makecostab(x);
-    x->x_usertable = x->x_usertableini;
-    x->x_usertable_tabsize = PDCYCYCLE_TABSIZE;
-	x->x_phaselet = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-	x->x_outlet = outlet_new(&x->x_obj, gensym("signal"));
-	if(offset < 0){
-		offset = 0;
-	};
+    x->x_phaselet = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+    x->x_outlet = outlet_new(&x->x_obj, gensym("signal"));
+    if(offset < 0){
+	    offset = 0;
+    };
     x->x_offset = offset;
-    if(anamedef){
-		x->x_name = name;
-    	}
-    else{
-		x->x_name = 0;
-	};
-	x->x_freq = freq;
-    x->x_table = 0;
+    x->x_nameset = name ? 1 : 0;
+    x->x_cybuf = cybuf_init((t_class *)x, name, 1, 0);
+    x->x_freq = freq;
     x->x_init_phase = phase;
     x->x_conv = 0.;
     cycle_set_buffersize(x, bufsz);
@@ -540,9 +415,7 @@ static void *cycle_new(t_symbol *s, int argc, t_atom *argv)
 
 static void *cycle_free(t_cycle *x)
 {
-	if (x->x_usertable != x->x_usertableini){
-		freebytes(x->x_usertable, (x->x_usertable_tabsize + 1) * sizeof(*x->x_usertable));
-	};
+        cybuf_free(x->x_cybuf);
 	//free(x->x_costable);
 	outlet_free(x->x_outlet);
 	inlet_free(x->x_phaselet);

--- a/cyclone_src/binaries/signal/cycle.c
+++ b/cyclone_src/binaries/signal/cycle.c
@@ -246,9 +246,7 @@ static t_int *cycle_perform(t_int *w)
 			*out++ = (t_float) (df1 + frac * (df2 - df1));
 		}
 		dphase += freq * conv ;
-                //overwrite phase arg
-                pd_float((t_pd *)x->x_phaselet, phasein);
-	}
+	};
 	
 	if (dphase>=1.)
 	{
@@ -262,6 +260,8 @@ static t_int *cycle_perform(t_int *w)
 		dphase -= intphase;
 	}
 	x->x_phase = dphase;
+        //overwrite phase arg, every block should be enough? - DK
+        pd_float((t_pd *)x->x_phaselet, phasein);
 	return (w + 6);
 }
 	

--- a/cyclone_src/help_files/coll-help.pd
+++ b/cyclone_src/help_files/coll-help.pd
@@ -1,4 +1,4 @@
-#N canvas 420 107 558 600 10;
+#N canvas 430 23 558 600 10;
 #X obj 2 284 cnv 3 550 3 empty empty inlets 8 12 0 13 -220534 -1 0
 ;
 #X obj 2 366 cnv 3 550 3 empty empty outlets 8 12 0 13 -228856 -1 0
@@ -28,7 +28,7 @@
 #X text 123 433 bang;
 #X obj 2 5 cnv 15 553 42 empty empty empty 20 12 0 14 -233017 -66577
 0;
-#N canvas 0 50 450 278 (subpatch) 0;
+#N canvas 0 22 450 278 (subpatch) 0;
 #X coords 0 1 100 -1 554 42 1 0 0;
 #X restore 2 4 graph;
 #X obj 305 5 cnv 15 250 40 empty empty empty 12 13 0 18 -128992 -233080
@@ -37,7 +37,7 @@
 #X coords 0 -1 1 1 252 42 2 100 100;
 #X restore 304 4 pd;
 #X text 101 462 1) symbol;
-#N canvas 720 50 641 578 All_Messages 0;
+#N canvas 720 23 641 578 All_Messages 0;
 #X text 119 181 length -;
 #X text 131 241 next -;
 #X text 131 301 open -;
@@ -188,13 +188,15 @@ data, f 64;
 #X msg 246 142 0 500 1000 hi;
 #X msg 256 166 1 5 10 hello;
 #X text 84 202 go to next address =>;
+#X obj 246 232 cyclone/coll;
+#C restore;
 #X text 156 291 outputs next address and its data, f 64;
 #X text 300 198 <= recall data from address;
 #X text 69 85 [coll] stores/edits any messages at given addresses (an
 integer or a symbol). If an input list starts with an int \, it stores
 the other element(s) at that int address.;
-#N canvas 566 99 622 589 examples 0;
-#N canvas 297 50 802 290 embbed 0;
+#N canvas 568 23 622 589 examples 0;
+#N canvas 297 37 802 290 embbed 0;
 #X msg 92 99 dump;
 #X obj 92 188 pack s f;
 #X msg 92 216 \$2 \$1;
@@ -234,7 +236,7 @@ patch.;
 #X connect 9 0 1 0;
 #X connect 9 1 1 1;
 #X restore 526 179 pd embbed;
-#N canvas 542 50 705 569 filetype 0;
+#N canvas 542 23 705 569 filetype 0;
 #X msg 371 136 filetype;
 #X text 83 213 The word filetype \, followed by a symbol \, sets the
 file types which can be read and written into the coll object. File
@@ -502,7 +504,7 @@ number (startng at 1). This element is then output to the left outlet.
 #X connect 26 0 25 0;
 #X connect 27 0 14 0;
 #X restore 517 460 pd min_max \; length \; nth;
-#N canvas 267 50 941 387 merge 0;
+#N canvas 267 40 941 387 merge 0;
 #X msg 42 143 1 one;
 #X msg 109 107 merge 1 two three;
 #X text 66 24 The merge message appends any message to an address.
@@ -749,7 +751,7 @@ in this case it acts in the same way as "remove".;
 #X connect 9 0 6 0;
 #X connect 10 0 2 0;
 #X restore 526 293 pd delete;
-#N canvas 117 50 548 370 refer 0;
+#N canvas 117 33 548 370 refer 0;
 #X msg 158 78 dump;
 #X obj 207 207 print address;
 #X obj 184 232 print value;
@@ -810,11 +812,8 @@ as the second argument.;
 can be viewed and edited by the [coll] objects in the right \, because
 they have the same name ('example1').;
 #X obj 31 336 cyclone/coll example1 1;
-#C restore;
 #X obj 193 242 cyclone/coll example1 1;
-#C restore;
 #X obj 282 421 cyclone/coll example1 1;
-#C restore;
 #X text 62 472 See how clearing the collection in one [coll] instance
 affects others with the same name - same with adding messages.;
 #X connect 0 0 16 0;
@@ -929,7 +928,7 @@ with the read/write messages.;
 #X connect 29 0 22 0;
 #X connect 30 0 22 0;
 #X restore 460 77 pd read/write files \; data navigation;
-#N canvas 175 50 787 431 alias 0;
+#N canvas 175 23 787 431 alias 0;
 #X obj 128 272 cyclone/coll;
 #C restore;
 #X msg 30 208 1;
@@ -1028,13 +1027,12 @@ collections;
 cloned from Max/MSP;
 #X obj 363 5 cyclone/comment 0 24 courier ? 0 224 228 220 cyclone;
 #X text 464 235 *;
-#N canvas 1 99 450 300 threaded 0;
+#N canvas 0 22 450 300 threaded 0;
 #X restore 480 234 pd threaded;
-#X obj 246 232 cyclone/coll;
-#C restore;
-#X connect 25 0 66 0;
-#X connect 33 0 66 0;
-#X connect 51 0 66 0;
-#X connect 52 0 66 0;
-#X connect 66 0 26 0;
-#X connect 66 1 27 0;
+#X connect 25 0 54 0;
+#X connect 33 0 54 0;
+#X connect 51 0 54 0;
+#X connect 52 0 54 0;
+#X connect 54 0 26 0;
+#X connect 54 1 27 0;
+

--- a/cyclone_src/help_files/coll-help.pd
+++ b/cyclone_src/help_files/coll-help.pd
@@ -1,4 +1,4 @@
-#N canvas 430 23 558 600 10;
+#N canvas 420 107 558 600 10;
 #X obj 2 284 cnv 3 550 3 empty empty inlets 8 12 0 13 -220534 -1 0
 ;
 #X obj 2 366 cnv 3 550 3 empty empty outlets 8 12 0 13 -228856 -1 0
@@ -28,7 +28,7 @@
 #X text 123 433 bang;
 #X obj 2 5 cnv 15 553 42 empty empty empty 20 12 0 14 -233017 -66577
 0;
-#N canvas 0 22 450 278 (subpatch) 0;
+#N canvas 0 50 450 278 (subpatch) 0;
 #X coords 0 1 100 -1 554 42 1 0 0;
 #X restore 2 4 graph;
 #X obj 305 5 cnv 15 250 40 empty empty empty 12 13 0 18 -128992 -233080
@@ -37,7 +37,7 @@
 #X coords 0 -1 1 1 252 42 2 100 100;
 #X restore 304 4 pd;
 #X text 101 462 1) symbol;
-#N canvas 720 23 641 578 All_Messages 0;
+#N canvas 720 50 641 578 All_Messages 0;
 #X text 119 181 length -;
 #X text 131 241 next -;
 #X text 131 301 open -;
@@ -188,15 +188,13 @@ data, f 64;
 #X msg 246 142 0 500 1000 hi;
 #X msg 256 166 1 5 10 hello;
 #X text 84 202 go to next address =>;
-#X obj 246 232 cyclone/coll;
-#C restore;
 #X text 156 291 outputs next address and its data, f 64;
 #X text 300 198 <= recall data from address;
 #X text 69 85 [coll] stores/edits any messages at given addresses (an
 integer or a symbol). If an input list starts with an int \, it stores
 the other element(s) at that int address.;
-#N canvas 568 23 622 589 examples 0;
-#N canvas 297 37 802 290 embbed 0;
+#N canvas 566 99 622 589 examples 0;
+#N canvas 297 50 802 290 embbed 0;
 #X msg 92 99 dump;
 #X obj 92 188 pack s f;
 #X msg 92 216 \$2 \$1;
@@ -236,7 +234,7 @@ patch.;
 #X connect 9 0 1 0;
 #X connect 9 1 1 1;
 #X restore 526 179 pd embbed;
-#N canvas 542 23 705 569 filetype 0;
+#N canvas 542 50 705 569 filetype 0;
 #X msg 371 136 filetype;
 #X text 83 213 The word filetype \, followed by a symbol \, sets the
 file types which can be read and written into the coll object. File
@@ -504,7 +502,7 @@ number (startng at 1). This element is then output to the left outlet.
 #X connect 26 0 25 0;
 #X connect 27 0 14 0;
 #X restore 517 460 pd min_max \; length \; nth;
-#N canvas 267 40 941 387 merge 0;
+#N canvas 267 50 941 387 merge 0;
 #X msg 42 143 1 one;
 #X msg 109 107 merge 1 two three;
 #X text 66 24 The merge message appends any message to an address.
@@ -751,7 +749,7 @@ in this case it acts in the same way as "remove".;
 #X connect 9 0 6 0;
 #X connect 10 0 2 0;
 #X restore 526 293 pd delete;
-#N canvas 117 33 548 370 refer 0;
+#N canvas 117 50 548 370 refer 0;
 #X msg 158 78 dump;
 #X obj 207 207 print address;
 #X obj 184 232 print value;
@@ -812,8 +810,11 @@ as the second argument.;
 can be viewed and edited by the [coll] objects in the right \, because
 they have the same name ('example1').;
 #X obj 31 336 cyclone/coll example1 1;
+#C restore;
 #X obj 193 242 cyclone/coll example1 1;
+#C restore;
 #X obj 282 421 cyclone/coll example1 1;
+#C restore;
 #X text 62 472 See how clearing the collection in one [coll] instance
 affects others with the same name - same with adding messages.;
 #X connect 0 0 16 0;
@@ -928,7 +929,7 @@ with the read/write messages.;
 #X connect 29 0 22 0;
 #X connect 30 0 22 0;
 #X restore 460 77 pd read/write files \; data navigation;
-#N canvas 175 23 787 431 alias 0;
+#N canvas 175 50 787 431 alias 0;
 #X obj 128 272 cyclone/coll;
 #C restore;
 #X msg 30 208 1;
@@ -1027,11 +1028,13 @@ collections;
 cloned from Max/MSP;
 #X obj 363 5 cyclone/comment 0 24 courier ? 0 224 228 220 cyclone;
 #X text 464 235 *;
-#N canvas 0 22 450 300 threaded 0;
+#N canvas 1 99 450 300 threaded 0;
 #X restore 480 234 pd threaded;
-#X connect 25 0 54 0;
-#X connect 33 0 54 0;
-#X connect 51 0 54 0;
-#X connect 52 0 54 0;
-#X connect 54 0 26 0;
-#X connect 54 1 27 0;
+#X obj 246 232 cyclone/coll;
+#C restore;
+#X connect 25 0 66 0;
+#X connect 33 0 66 0;
+#X connect 51 0 66 0;
+#X connect 52 0 66 0;
+#X connect 66 0 26 0;
+#X connect 66 1 27 0;

--- a/cyclone_src/help_files/coll-help.pd
+++ b/cyclone_src/help_files/coll-help.pd
@@ -1035,4 +1035,3 @@ cloned from Max/MSP;
 #X connect 52 0 54 0;
 #X connect 54 0 26 0;
 #X connect 54 1 27 0;
-


### PR DESCRIPTION
cybuffed. it seems before my changes, the user wavetable defaulted to the whole buffer instead of 512 samples, which i'm doing now. which is preferred? 

also, overwriting the default value of x->x_phaselet (the phase inlet) with what signal is coming in it. i'm not sure if this is what you're talking about so tell me if it isn't. made it overwrite at every block instead of every sample, should be good enough...