### PR TITLE
past: redone to fit description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ midiformat.class.sources := cyclone_src/binaries/control/midiformat.c
 midiparse.class.sources := cyclone_src/binaries/control/midiparse.c
 next.class.sources := cyclone_src/binaries/control/next.c
 onebang.class.sources := cyclone_src/binaries/control/onebang.c
+past.class.sources := cyclone_src/binaries/control/past.c
 peak.class.sources := cyclone_src/binaries/control/peak.c
 poltocar.class.sources := cyclone_src/binaries/control/poltocar.c
 sinh.class.sources := cyclone_src/binaries/control/sinh.c
@@ -272,7 +273,6 @@ pv.class.sources := cyclone_src/binaries/control/pv.c $(hgrow)
 # hgrowfitter classes
 append.class.sources := cyclone_src/binaries/control/append.c $(hgrowfitter)
 prepend.class.sources := cyclone_src/binaries/control/prepend.c $(hgrowfitter)
-past.class.sources := cyclone_src/binaries/control/past.c $(hgrowfitter)
 
 # hloud classes
 anal.class.sources := cyclone_src/binaries/control/anal.c $(hloud)


### PR DESCRIPTION
pretty much scrapped all the old code (except the past_setup method). setting the args uses a helper past_set_helper that first copies everything to a stack variable and if none of the t_atoms are symbols, copies it to the actual object. i've done this so that if you set a list that doesn't work (ie has a symbol in there) then you still get to keep the old settings.

in my version, thresholds CANNOT be met if the input list is smaller than the object's list or if there is a symbol in the input list.the first because you don't have enough values to compare so how could you possibly meet any threshold, the second because symbols aren't floats. 

i've also done that when you have a successful [set(, the threshold is reset (so it's like sending "clear" as well). 