### PR TITLE
cycle: remove symbol selector, buddy: change behavior of buddy_proxy_bang

### DIFF
--- a/cyclone_src/binaries/control/bondo.c
+++ b/cyclone_src/binaries/control/bondo.c
@@ -64,11 +64,15 @@ static void bondo_doit(t_bondo *x)
 	    outlet_float(x->x_outs[i], p[i]->p_float);
 	else if (s == &s_symbol && p[i]->p_symbol)
 	{
+            
+	    outlet_symbol(x->x_outs[i], p[i]->p_symbol);
 	    /* LATER rethink */
+            /* old code
 	    if (x->x_multiatom)
 		outlet_symbol(x->x_outs[i], p[i]->p_symbol);
 	    else
 		outlet_anything(x->x_outs[i], p[i]->p_symbol, 0, 0);
+            */
 	}
 	else if (s == &s_pointer)
 	{

--- a/cyclone_src/binaries/control/buddy.c
+++ b/cyclone_src/binaries/control/buddy.c
@@ -79,19 +79,22 @@ static void buddy_check(t_buddy *x)
     buddy_clear(x);
 }
 
-static void buddy_proxy_bang(t_buddy_proxy *x)
-{
-    x->p_selector = &s_bang;
-    x->p_natoms = 0;  /* defensive */
-    buddy_check(x->p_master);
-}
-
 static void buddy_proxy_float(t_buddy_proxy *x, t_float f)
 {
     x->p_selector = &s_float;
     x->p_float = f;
     x->p_natoms = 0;  /* defensive */
     buddy_check(x->p_master);
+}
+
+static void buddy_proxy_bang(t_buddy_proxy *x)
+{
+
+    buddy_proxy_float(x, 0)
+    //x->p_selector = &s_bang;
+    //x->p_natoms = 0;  /* defensive */
+    //buddy_check(x->p_master);
+    
 }
 
 static void buddy_proxy_symbol(t_buddy_proxy *x, t_symbol *s)

--- a/cyclone_src/binaries/control/cycle.c
+++ b/cyclone_src/binaries/control/cycle.c
@@ -77,7 +77,7 @@ static void cycle_list(t_cycle *x, t_symbol *s, int ac, t_atom *av)
 	if (av->a_type == A_FLOAT)
 	    outlet_float(x->x_outs[x->x_index], av->a_w.w_float);
 	else if (av->a_type == A_SYMBOL)
-	    outlet_symbol(x->x_outs[x->x_index], av->a_w.w_symbol);
+	    outlet_anything(x->x_outs[x->x_index], av->a_w.w_symbol, 0, 0);
 	av++;
 	if (++(x->x_index) >= x->x_nouts) x->x_index = 0;
     }


### PR DESCRIPTION
cycle: remove symbol selector, buddy: change behavior of buddy_proxy_bang

bondo: there was a conditional for multiatom (list mode) that made it use outlet_symbol for multiatom and outlet_anything (no selector) for not in that mode,.. i got rid of the conditional and just used outlet_symbol for everything, not sure if it does what it's supposed to...