### PR TITLE
pv: adding default symbol

### DIFF
--- a/cyclone_src/binaries/control/pv.c
+++ b/cyclone_src/binaries/control/pv.c
@@ -397,7 +397,7 @@ static void *pv_new(t_symbol *s, int ac, t_atom *av)
     t_pv *x = 0;
     if (ac && av->a_type == A_SYMBOL)
 	s = av->a_w.w_symbol;
-    else s = 0;
+    else s = gensym("_cyclone-pv-default");
     if (s && s != &s_)
     {
 	t_glist *gl = canvas_getcurrent();


### PR DESCRIPTION
added a default symbol as "_cyclone-pv-default". objections?

also, see my explanation for send on the github issue. there's no global binding, it basically calls pd_float (or pd_symbol or whatever) when it needs to send something.