### PR TITLE
capture~: fixing shawdowed s, removing loud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,6 @@ sgrow := shared/common/grow.c
 
 sfile := \
 shared/hammer/file.c \
-shared/common/loud.c \
 shared/common/os.c
     capture~.class.sources := cyclone_src/binaries/signal/capture.c $(sfile)
 

--- a/cyclone_src/binaries/signal/capture.c
+++ b/cyclone_src/binaries/signal/capture.c
@@ -7,9 +7,11 @@
 #include <stdio.h>
 #include "m_pd.h"
 #include "g_canvas.h"
-#include "common/loud.h"
 #include "hammer/file.h"
+#include <string.h>
+#include <errno.h>
 
+//string and errno for fail: in capture_dowrite, copying over functionality from loud.c
 #define CAPTURE_DEFSIZE     4096
 #define CAPTURE_DEFPRECISION   4
 #define CAPTURE_MAXPRECISION  99  /* format array protection */
@@ -104,7 +106,8 @@ static void capture_dowrite(t_capture *x, t_symbol *fn)
     }
 fail:
     if (fp) fclose(fp);
-    loud_syserror((t_pd *)x, 0);
+    //loud_syserror((t_pd *)x, 0);
+    pd_error(x, "capture~: %s", strerror(errno));
 }
 
 static void capture_writehook(t_pd *z, t_symbol *fn, int ac, t_atom *av)
@@ -314,8 +317,8 @@ static void *capture_new(t_symbol *s, int ac, t_atom *av)
     int szindices = 0, nindices = -1;
     if (ac && av->a_type == A_SYMBOL)
     {
-	t_symbol *s = av->a_w.w_symbol;
-	if (s && *s->s_name == 'f')  /* CHECKME */
+	t_symbol *cursym = av->a_w.w_symbol;
+	if (cursym && *cursym->s_name == 'f')  /* CHECKME */
 	    mode = 'f';
 	ac--; av++;
     }


### PR DESCRIPTION
there was a shadowed declaration of t_symbol *s in capture_new, i changed the shadowed declaration to t_symbol *cursym. 

got rid of the loud entry for sfile (only seemed to include capture~) in the makefile.  didn't rename sfile to something else.

the loud dependency was only for loud_syserror, which depends on loud_error. it basically passed a strerror(errno) to pd_error. not sure if it this works, (no trouble yet). the fputs functions used that need to fail to get to the fail state seem to set the errno.....  also i needed to include <string.h> and <errno.h> for this. seems errno is cross-platform...