### PR TITLE
coll: 3rd outlet bang new instance mods

### DIFF
--- a/cyclone_src/binaries/control/coll.c
+++ b/cyclone_src/binaries/control/coll.c
@@ -1115,7 +1115,7 @@ static void coll_bind(t_coll *x, t_symbol *name)
     else{
         //bang if you find collcommon existing already,
         //but shouldn't be for no search
-        if(!no_search){
+        if(!no_search && cc->c_filename != 0){
             x->x_filebang = 1;
 	    x->x_initread = 1;
             clock_delay(x->x_clock, 0);


### PR DESCRIPTION
this should KEEP bangs on new instances of colls where the original was bound to a symbol not corresponding to a file but later read a file (and thus binding it to a filename)

this should FIX other cases though, like the above case but where read was NOT called. 