### PR TITLE
remove offset ndx by cnt

### DIFF
--- a/cyclone_src/binaries/control/table.c
+++ b/cyclone_src/binaries/control/table.c
@@ -311,8 +311,8 @@ static void table_embedhook(t_pd *z, t_binbuf *bb, t_symbol *bindsym){
         while(left > 0){
             int cnt = (left > 128 ? 128 : left);
             left -= cnt;
-            ndx += cnt;
-            binbuf_addv(bb, "ssi", bindsym, gensym("set"), ndx);
+            //ndx += cnt;
+	    binbuf_addv(bb, "ssi", bindsym, gensym("set"), ndx);
             while(cnt--){
                 t_atom at;
                 SETFLOAT(&at, (float)*ptr);

--- a/shared/common/file.c
+++ b/shared/common/file.c
@@ -820,7 +820,7 @@ t_hammerfile *hammerfile_new(t_pd *master, t_hammerembedfn embedfn,
 	/* just in case of missing 'restore' */
 	hammerembed_gc(master, ps__C, 0);
 	if (hammerfile_isloading(result) || hammerfile_ispasting(result))
-	    pd_bind(master, ps__C);
+	  pd_bind(master, ps__C);
     }
 
     /* 2. the panels */


### PR DESCRIPTION
i think ndx shouldn't be offset by count? it ndx is that element that appears in the save patch #C set ndx (tablevals) that sends the "set" method to table upon loading,...  and according to your docu for the set method ndx should be the starting index,.. which should be 0 each time (i think)