### PR TITLE
MSVC fixes

### DIFF
--- a/cyclone_objects/binaries/audio/change.c
+++ b/cyclone_objects/binaries/audio/change.c
@@ -8,7 +8,7 @@ typedef struct _change
 {
     t_object x_obj;
     t_float  x_last;
-    t_outlet *x_outlet
+    t_outlet *x_outlet;
 } t_change;
 
 static t_class *change_class;

--- a/cyclone_objects/binaries/audio/cross.c
+++ b/cyclone_objects/binaries/audio/cross.c
@@ -1,6 +1,7 @@
 // Porres 2016
 
 #include "m_pd.h"
+#define _USE_MATH_DEFINES
 #include <math.h>
 
 #define PI M_PI

--- a/cyclone_objects/binaries/audio/cycle.c
+++ b/cyclone_objects/binaries/audio/cycle.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include <string.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdlib.h>
 #include "m_pd.h"

--- a/cyclone_objects/binaries/audio/frameaccum.c
+++ b/cyclone_objects/binaries/audio/frameaccum.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include <string.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include "m_pd.h"
 #include "common/grow.h"

--- a/cyclone_objects/binaries/audio/lores.c
+++ b/cyclone_objects/binaries/audio/lores.c
@@ -7,6 +7,7 @@
 
 /* CHECKME if creation args (or defaults) restored after signal disconnection */
 
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include "m_pd.h"
 

--- a/cyclone_objects/binaries/audio/onepole.c
+++ b/cyclone_objects/binaries/audio/onepole.c
@@ -7,6 +7,7 @@
 /* CHECKED scalar case: input preserved (not coefs) after changing mode */
 /* CHECKME if creation arg (or a default) restored after signal disconnection */
 
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include "m_pd.h"
 

--- a/cyclone_objects/binaries/audio/phaseshift.c
+++ b/cyclone_objects/binaries/audio/phaseshift.c
@@ -1,6 +1,7 @@
 // Porres 2016
 
 #include "m_pd.h"
+#define _USE_MATH_DEFINES
 #include <math.h>
 
 #define PI M_PI

--- a/cyclone_objects/binaries/audio/reson.c
+++ b/cyclone_objects/binaries/audio/reson.c
@@ -8,6 +8,7 @@
 
 /* CHECKME if creation args (or defaults) restored after signal disconnection */
 
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include "m_pd.h"
 

--- a/cyclone_objects/binaries/audio/scope.c
+++ b/cyclone_objects/binaries/audio/scope.c
@@ -1606,7 +1606,7 @@ static t_widgetbehavior scope_widgetbehavior =
     scope_delete,
     scope_vis,
     scope_click,
-    0,0 // instead of FORKY_WIDGETPADDING
+    //0,0 // instead of FORKY_WIDGETPADDING
 };
 
 static void scope_setxymode(t_scope *x, int xymode)

--- a/cyclone_objects/binaries/audio/svf.c
+++ b/cyclone_objects/binaries/audio/svf.c
@@ -9,6 +9,7 @@
 /* CHECKED scalar case: input preserved (not coefs) after changing mode */
 /* CHECKME if creation args (or defaults) restored after signal disconnection */
 
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include "m_pd.h"
 

--- a/cyclone_objects/binaries/audio/wave.c
+++ b/cyclone_objects/binaries/audio/wave.c
@@ -107,7 +107,7 @@ static void wave_set(t_wave *x, t_symbol *s)
 	ndx1 = ndx + 1; \
 	if (ndx1 == eposi) ndx1 = sposi
 	
-#define INDEX_4PT() \ 
+#define INDEX_4PT() \
 	int ndxm1, ndx1, ndx2; \
 	double a, b, c, d; \
 	double xpos = phase*siz + spos; \

--- a/cyclone_objects/binaries/audio/wave.c
+++ b/cyclone_objects/binaries/audio/wave.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include <string.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include "m_pd.h"
 #include "signal/cybuf.h"

--- a/cyclone_objects/binaries/control/capture.c
+++ b/cyclone_objects/binaries/control/capture.c
@@ -426,7 +426,8 @@ static void capture_anything(t_capture *x, t_symbol *s, int argc, t_atom * argv)
             if(strcmp(s->s_name, "list") != 0 || argv->a_type != A_FLOAT){
                 //copy list to new t_atom with symbol as first elt
                 int destpos = 0; //position in copied list
-                t_atom at[argc+1];
+                int atsize = argc + 1;
+                t_atom* at = t_getbytes(atsize * sizeof(*at));
                 SETSYMBOL(&at[destpos], s);
                 destpos++;
                 int arrpos = 0; //position in arriving list
@@ -444,6 +445,7 @@ static void capture_anything(t_capture *x, t_symbol *s, int argc, t_atom * argv)
                 arrpos++;
                 };
                 capture_list(x, s, argc+1, at);
+                t_freebytes(at, atsize * sizeof(*at));
             }
             else{
                 capture_list(x, s, argc, argv);

--- a/cyclone_objects/binaries/control/coll.c
+++ b/cyclone_objects/binaries/control/coll.c
@@ -17,7 +17,9 @@ before used to always bang on callback, now only bangs now due to new x->x_fileb
 #include "common/file.h"
 
 #include <pthread.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 
 /* LATER profile for the bottlenecks of insertion and sorting */
 /* LATER make sure that ``reentrancy protection hack'' is really working... */

--- a/cyclone_objects/binaries/control/comment.c
+++ b/cyclone_objects/binaries/control/comment.c
@@ -468,8 +468,8 @@ static t_widgetbehavior comment_widgetbehavior =
     0,
     comment_vis,
     0,
-    0,
-    0
+    /*0,
+    0*/
 };
 
 /* this fires if a transform request was sent to a symbol we are bound to */

--- a/cyclone_objects/binaries/control/comment.c
+++ b/cyclone_objects/binaries/control/comment.c
@@ -723,7 +723,7 @@ static void comment_suppressinlet(t_comment *x, t_float f)
 //end new method placeholders
 static void comment_attrparser(t_comment *x, int argc, t_atom * argv)
 {
-    t_atom comlist[argc];
+    t_atom* comlist = t_getbytes(argc * sizeof(*comlist));
     int i, comlen = 0; //eventual length of comment list comlist 
     for(i=0;i<argc; i++)
     {
@@ -846,6 +846,7 @@ static void comment_attrparser(t_comment *x, int argc, t_atom * argv)
 	SETSYMBOL(&comlist[0], gensym("comment"));
 	binbuf_restore(x->x_binbuf, 1, comlist);
     };
+    t_freebytes(comlist, argc * sizeof(*comlist));
 }
 
 

--- a/cyclone_objects/binaries/control/fromsymbol.c
+++ b/cyclone_objects/binaries/control/fromsymbol.c
@@ -105,18 +105,18 @@ static void fromsymbol_symbol(t_fromsymbol *x, t_symbol *s){
     //new and redone - Derek Kwan
     long unsigned int seplen = strlen(x->x_separator->s_name);
     seplen++;
-    char sep[seplen];
+    char sep[MAXPDSTRING];
     memset(sep, '\0', sizeof(seplen));
     strcpy(sep, x->x_separator->s_name);
     //char * sep = x->x_separator->s_name;
     if(s){
         //get length of input string
         long unsigned int iptlen = strlen(s->s_name);
-        //allocate t_atom [] on stack length of string
+        //allocate t_atom [] on length of string
         //(hacky way of making sure there's enough space)
-        t_atom out[iptlen];
+        t_atom* out = t_getbytes(iptlen * sizeof(*out));
         iptlen++;
-        char newstr[iptlen];
+        char newstr[MAXPDSTRING];
         memset(newstr, '\0', sizeof(newstr));
         strcpy(newstr,s->s_name);
         int atompos = 0; //position in atom
@@ -148,7 +148,7 @@ static void fromsymbol_symbol(t_fromsymbol *x, t_symbol *s){
                 outlet_list(((t_object *)x)->ob_outlet, &s_list, atompos, out);
              };
         };
-        
+        t_freebytes(out, iptlen * sizeof(*out));
     };
 }
 

--- a/cyclone_objects/binaries/control/mtr.c
+++ b/cyclone_objects/binaries/control/mtr.c
@@ -195,7 +195,8 @@ static void mtrack_anything(t_mtrack *tp, t_symbol *s, int ac, t_atom *av)
             if(strcmp(s->s_name, "list") != 0 || av->a_type != A_FLOAT){
                 //copy list to new t_atom with symbol as first elt
                 int destpos = 0; //position in copied list
-                t_atom at[ac+1];
+                int atsize = ac + 1;
+                t_atom* at = t_getbytes(atsize * sizeof(*at));
                 SETSYMBOL(&at[destpos], s);
                 destpos++;
                 int arrpos = 0; //position in arriving list
@@ -213,6 +214,7 @@ static void mtrack_anything(t_mtrack *tp, t_symbol *s, int ac, t_atom *av)
                 arrpos++;
                 };
                 mtrack_doadd(tp, ac+1, &at);
+                t_freebytes(at, atsize * sizeof(*at));
             }
             else{
                 mtrack_doadd(tp, ac, av);

--- a/cyclone_objects/binaries/control/past.c
+++ b/cyclone_objects/binaries/control/past.c
@@ -72,7 +72,7 @@ static void past_alloc(t_past *x, int argc){
 
 static int past_set_helper(t_past * x, int argc, t_atom * argv)
 {
-    t_float parse[argc];
+    t_float* parse = t_getbytes(argc * sizeof(*parse));
     int i, errors = 0;
     for(i=0; i < argc; i++){
         if((argv+i)->a_type == A_FLOAT){
@@ -97,6 +97,7 @@ static int past_set_helper(t_past * x, int argc, t_atom * argv)
         x->x_argsz = argc;
         return 0;
     };
+    t_freebytes(parse, argc * sizeof(*parse));
 }
 
 static void past_set(t_past *x, t_symbol *s, int argc, t_atom * argv)

--- a/cyclone_objects/binaries/control/unjoin.c
+++ b/cyclone_objects/binaries/control/unjoin.c
@@ -65,13 +65,14 @@ static void unjoin_anything(t_unjoin * x, t_symbol *s, int argc, t_atom * argv)
     if(s)
     {
         int i;
-        t_atom newlist[argc+1];
+        t_atom* newlist = t_getbytes((argc + 1) * sizeof(*newlist));
         SETSYMBOL(&newlist[0],s);
         for(i=0;i<argc;i++)
         {
             newlist[i+1] = argv[i];
         };
         unjoin_list(x, NULL, argc+1, newlist);
+        t_freebytes(newlist, (argc + 1) * sizeof(*newlist));
     }
     else unjoin_list(x, NULL, argc, argv);
 }

--- a/cyclone_objects/binaries/cyclone_lib.c
+++ b/cyclone_objects/binaries/cyclone_lib.c
@@ -661,7 +661,7 @@ void cyclone_setup(void)
 
     char cyclone_dir[MAXPDSTRING];
     strcpy(cyclone_dir, cyclone_class->c_externdir->s_name);
-    char encoded[strlen(cyclone_dir)+1];
+    char encoded[MAXPDSTRING+1];
     sprintf(encoded, "+%s", cyclone_dir);
 
     t_atom ap[2];


### PR DESCRIPTION
Here are several fixes that are necessary to compile the cyclone under MSVC. (Microsoft Visual C++ compiler i.e. the compiler included in Visual Studio)
Mostly enabling math constant definitions and using dynamic memory for non-constant size arrays.
Nevertheless, I think in some of the cases where `t_atom` arrays are populated the code could be simplified by using [`binbuf_*`](https://github.com/pure-data/pure-data/blob/7c27aa0ad505bb4802eee3fc40886836c814353f/src/m_pd.h#L340) functions.