### PR TITLE
Export setup symbols if appropriate

### DIFF
--- a/cyclone_objects/binaries/audio/acos.c
+++ b/cyclone_objects/binaries/audio/acos.c
@@ -4,6 +4,8 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
+
 // magic needed for manual isnan and isinf checks, which don't work
 // reliably with -ffast-math compiler option
 //#include "magicbit.h"
@@ -46,7 +48,7 @@ void *acos_new(void)
     return (x);
 }
 
-void acos_tilde_setup(void)
+CYCLONE_OBJ_API void acos_tilde_setup(void)
 {
     acos_class = class_new(gensym("acos~"), (t_newmethod)acos_new, 0,
         sizeof(t_acos), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/acosh.c
+++ b/cyclone_objects/binaries/audio/acosh.c
@@ -4,6 +4,8 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
+
 // magic needed for manual isnan and isinf checks, which don't work
 // reliably with -ffast-math compiler option
 //#include "magicbit.h"
@@ -46,7 +48,7 @@ void *acosh_new(void)
     return (x);
 }
 
-void acosh_tilde_setup(void)
+CYCLONE_OBJ_API void acosh_tilde_setup(void)
 {
     acosh_class = class_new(gensym("acosh~"), (t_newmethod)acosh_new, 0,
                            sizeof(t_acosh), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/allpass.c
+++ b/cyclone_objects/binaries/audio/allpass.c
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define ALLPASS_STACK 48000 //stack buf size, 1 sec at 48k for good measure
 #define ALLPASS_DELAY  10.0 //maximum delay
@@ -304,7 +305,7 @@ static void * allpass_free(t_allpass *x){
     return (void *)x;
 }
 
-void allpass_tilde_setup(void)
+CYCLONE_OBJ_API void allpass_tilde_setup(void)
 {
     allpass_class = class_new(gensym("allpass~"),
 			   (t_newmethod)allpass_new,

--- a/cyclone_objects/binaries/audio/asin.c
+++ b/cyclone_objects/binaries/audio/asin.c
@@ -4,6 +4,8 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
+
 // magic needed for manual isnan and isinf checks, which don't work
 // reliably with -ffast-math compiler option
 //#include "magicbit.h"
@@ -46,7 +48,7 @@ void *asin_new(void)
     return (x);
 }
 
-void asin_tilde_setup(void)
+CYCLONE_OBJ_API void asin_tilde_setup(void)
 {
     asin_class = class_new(gensym("asin~"), (t_newmethod)asin_new, 0,
                            sizeof(t_asin), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/asinh.c
+++ b/cyclone_objects/binaries/audio/asinh.c
@@ -4,6 +4,8 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
+
 
 typedef struct _asinh {
     t_object x_obj;
@@ -42,7 +44,7 @@ void *asinh_new(void)
     return (x);
 }
 
-void asinh_tilde_setup(void)
+CYCLONE_OBJ_API void asinh_tilde_setup(void)
 {
     asinh_class = class_new(gensym("asinh~"), (t_newmethod)asinh_new, 0,
                            sizeof(t_asinh), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/atan.c
+++ b/cyclone_objects/binaries/audio/atan.c
@@ -4,6 +4,8 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
+
 
 typedef struct _atan {
     t_object x_obj;
@@ -42,7 +44,7 @@ void *atan_new(void)
     return (x);
 }
 
-void atan_tilde_setup(void)
+CYCLONE_OBJ_API void atan_tilde_setup(void)
 {
     atan_class = class_new(gensym("atan~"), (t_newmethod)atan_new, 0,
                             sizeof(t_atan), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/atan2.c
+++ b/cyclone_objects/binaries/audio/atan2.c
@@ -4,6 +4,8 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
+
 
 typedef struct _atan2 {
     t_object    x_obj;
@@ -45,7 +47,7 @@ static void *atan2_new(t_floatarg f) // arg = x (not documented in max)
     return (x);
 }
 
-void atan2_tilde_setup(void)
+CYCLONE_OBJ_API void atan2_tilde_setup(void)
 {
     atan2_class = class_new(gensym("atan2~"), (t_newmethod)atan2_new, 0,
         sizeof(t_atan2), CLASS_DEFAULT, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/audio/atanh.c
+++ b/cyclone_objects/binaries/audio/atanh.c
@@ -4,6 +4,8 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
+
 // magic needed for manual isnan and isinf checks, which don't work
 // reliably with -ffast-math compiler option
 //#include "magicbit.h"
@@ -46,7 +48,7 @@ void *atanh_new(void)
     return (x);
 }
 
-void atanh_tilde_setup(void)
+CYCLONE_OBJ_API void atanh_tilde_setup(void)
 {
     atanh_class = class_new(gensym("atanh~"), (t_newmethod)atanh_new, 0,
                            sizeof(t_atanh), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/atodb.c
+++ b/cyclone_objects/binaries/audio/atodb.c
@@ -10,6 +10,7 @@
  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 
 static t_class *atodb_class;
@@ -44,7 +45,7 @@ static void *atodb_new(void){
   return (void *)x;
 }
 
-void atodb_tilde_setup(void) {
+CYCLONE_OBJ_API void atodb_tilde_setup(void) {
   atodb_class = class_new(gensym("atodb~"),
        (t_newmethod) atodb_new, 0, sizeof (t_atodb), CLASS_DEFAULT, 0);
   class_addmethod(atodb_class, nullfn, gensym("signal"), 0);

--- a/cyclone_objects/binaries/audio/average.c
+++ b/cyclone_objects/binaries/audio/average.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define AVERAGE_STACK    44100 //stack value
 #define AVERAGE_MAXBUF  882000 //max buffer size
@@ -300,7 +301,7 @@ static void *average_new(t_symbol *s, int argc, t_atom * argv)
     return (x);
 }
 
-void average_tilde_setup(void)
+CYCLONE_OBJ_API void average_tilde_setup(void)
 {
     average_class = class_new(gensym("average~"), (t_newmethod)average_new,
             (t_method)average_free, sizeof(t_average), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/avg.c
+++ b/cyclone_objects/binaries/audio/avg.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _avg
 {
@@ -52,7 +53,7 @@ static void *avg_new(void)
     return (x);
 }
 
-void avg_tilde_setup(void)
+CYCLONE_OBJ_API void avg_tilde_setup(void)
 {
     avg_class = class_new(gensym("avg~"),
 			  (t_newmethod)avg_new, 0,

--- a/cyclone_objects/binaries/audio/bitand.c
+++ b/cyclone_objects/binaries/audio/bitand.c
@@ -4,6 +4,7 @@
 
 //#include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 
 // EXTERN t_float *obj_findsignalscalar(t_object *x, int m);
@@ -144,7 +145,7 @@ static void *bitand_new(t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void bitand_tilde_setup(void)
+CYCLONE_OBJ_API void bitand_tilde_setup(void)
 {
     bitand_class = class_new(gensym("bitand~"), (t_newmethod)bitand_new, 0,
         sizeof(t_bitand), 0, A_DEFFLOAT, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/audio/bitnot.c
+++ b/cyclone_objects/binaries/audio/bitnot.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 
 //~ union i32_fl {
@@ -75,7 +76,7 @@ void *bitnot_new(t_floatarg f)
     return (x);
 }
 
-void bitnot_tilde_setup(void) {
+CYCLONE_OBJ_API void bitnot_tilde_setup(void) {
     bitnot_class = class_new(gensym("bitnot~"), (t_newmethod) bitnot_new, 0,
         sizeof (t_bitnot), CLASS_DEFAULT, A_DEFFLOAT, 0);
     class_addmethod(bitnot_class, nullfn, gensym("signal"), 0);

--- a/cyclone_objects/binaries/audio/bitor.c
+++ b/cyclone_objects/binaries/audio/bitor.c
@@ -4,6 +4,7 @@
 
 //#include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 
 //EXTERN t_float *obj_findsignalscalar(t_object *x, int m);
@@ -148,7 +149,7 @@ static void *bitor_new(t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void bitor_tilde_setup(void)
+CYCLONE_OBJ_API void bitor_tilde_setup(void)
 {
     bitor_class = class_new(gensym("bitor~"), (t_newmethod)bitor_new, 0,
         sizeof(t_bitor), 0, A_DEFFLOAT, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/audio/bitsafe.c
+++ b/cyclone_objects/binaries/audio/bitsafe.c
@@ -2,6 +2,7 @@
  
 //#include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 // magic.h needed for magic_isnan() and magic_isinf()
 #include "common/magicbit.h"
 
@@ -43,7 +44,7 @@ void *bitsafe_new(void)
     return (x);
 }
 
-void bitsafe_tilde_setup(void)
+CYCLONE_OBJ_API void bitsafe_tilde_setup(void)
 {
     bitsafe_class = class_new(gensym("bitsafe~"), (t_newmethod)bitsafe_new, 0,
                               sizeof(t_bitsafe), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/bitshift.c
+++ b/cyclone_objects/binaries/audio/bitshift.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 
 static t_class *bitshift_class;
@@ -107,7 +108,7 @@ void *bitshift_new(t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void bitshift_tilde_setup(void) { bitshift_class = class_new(gensym("bitshift~"),
+CYCLONE_OBJ_API void bitshift_tilde_setup(void) { bitshift_class = class_new(gensym("bitshift~"),
         (t_newmethod) bitshift_new, 0, sizeof (t_bitshift), CLASS_DEFAULT,
         A_DEFFLOAT, A_DEFFLOAT, 0);
     class_addfloat(bitshift_class, (t_method)bitshift_float);

--- a/cyclone_objects/binaries/audio/bitxor.c
+++ b/cyclone_objects/binaries/audio/bitxor.c
@@ -7,6 +7,7 @@
 #include <string.h>
 //#include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 
 #define PDCYBXORMASK 0 //default for bitmask
@@ -206,7 +207,7 @@ static void *bitxor_new(t_symbol *s, int argc, t_atom * argv)
 
 }
 
-void bitxor_tilde_setup(void)
+CYCLONE_OBJ_API void bitxor_tilde_setup(void)
 {
     bitxor_class = class_new(gensym("bitxor~"), (t_newmethod)bitxor_new, 0,
                             sizeof(t_bitxor), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/buffir.c
+++ b/cyclone_objects/binaries/audio/buffir.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "signal/cybuf.h"
 
 #define BUFFIR_DEFSIZE    0
@@ -169,7 +170,7 @@ static void *buffir_new(t_symbol *s, t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void buffir_tilde_setup(void)
+CYCLONE_OBJ_API void buffir_tilde_setup(void)
 {
     buffir_class = class_new(gensym("buffir~"), (t_newmethod)buffir_new, (t_method)buffir_free,
     sizeof(t_buffir), CLASS_DEFAULT, A_DEFSYM, A_DEFFLOAT, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/audio/capture.c
+++ b/cyclone_objects/binaries/audio/capture.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "g_canvas.h"
 #include "common/file.h"
 #include <string.h>
@@ -390,7 +391,7 @@ static void *capture_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void capture_tilde_setup(void)
+CYCLONE_OBJ_API void capture_tilde_setup(void)
 {
     capture_class = class_new(gensym("capture~"),
 			      (t_newmethod)capture_new,

--- a/cyclone_objects/binaries/audio/cartopol.c
+++ b/cyclone_objects/binaries/audio/cartopol.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 
 typedef struct _cartopol
@@ -112,7 +113,7 @@ static void *cartopol_new(void)
     return (x);
 }
 
-void cartopol_tilde_setup(void)
+CYCLONE_OBJ_API void cartopol_tilde_setup(void)
 {
     cartopol_class = class_new(gensym("cartopol~"), (t_newmethod)cartopol_new, 0,
             sizeof(t_cartopol), 0, 0);

--- a/cyclone_objects/binaries/audio/change.c
+++ b/cyclone_objects/binaries/audio/change.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _change
 {
@@ -54,7 +55,7 @@ static void *change_new(void)
     return (x);
 }
 
-void change_tilde_setup(void)
+CYCLONE_OBJ_API void change_tilde_setup(void)
 {
     change_class = class_new(gensym("change~"), (t_newmethod)change_new, 0,
             sizeof(t_change), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/click.c
+++ b/cyclone_objects/binaries/audio/click.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define CLICK_MAX_SIZE  256  
 
@@ -102,7 +103,7 @@ static void *click_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void click_tilde_setup(void)
+CYCLONE_OBJ_API void click_tilde_setup(void)
 {
     click_class = class_new(gensym("click~"),
 			    (t_newmethod)click_new,

--- a/cyclone_objects/binaries/audio/clip.c
+++ b/cyclone_objects/binaries/audio/clip.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define CLIP_DEFLO  0.
 #define CLIP_DEFHI  0.
@@ -87,8 +88,7 @@ errstate:
     return NULL;
 }
 
-
-void clip_tilde_setup(void)
+CYCLONE_OBJ_API void clip_tilde_setup(void)
 {
     clip_class = class_new(gensym("cyclone/clip~"),
 			   (t_newmethod)clip_new, 0, sizeof(t_clip), CLASS_DEFAULT, A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/comb.c
+++ b/cyclone_objects/binaries/audio/comb.c
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define COMB_STACK 48000 //stack buf size, 1 sec at 48k for good measure
 #define COMB_DELAY  10.0 //maximum delay
@@ -332,7 +333,7 @@ static void * comb_free(t_comb *x){
     return (void *)x;
 }
 
-void comb_tilde_setup(void)
+CYCLONE_OBJ_API void comb_tilde_setup(void)
 {
     comb_class = class_new(gensym("comb~"),
 			   (t_newmethod)comb_new,

--- a/cyclone_objects/binaries/audio/cosh.c
+++ b/cyclone_objects/binaries/audio/cosh.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _cosh {
     t_object x_obj;
@@ -42,7 +43,7 @@ void *cosh_new(void)
     return (x);
 }
 
-void cosh_tilde_setup(void)
+CYCLONE_OBJ_API void cosh_tilde_setup(void)
 {
     cosh_class = class_new(gensym("cosh~"), (t_newmethod)cosh_new, 0,
                             sizeof(t_cosh), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/cosx.c
+++ b/cyclone_objects/binaries/audio/cosx.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _cosx {
     t_object x_obj;
@@ -42,7 +43,7 @@ void *cosx_new(void)
     return (x);
 }
 
-void cosx_tilde_setup(void)
+CYCLONE_OBJ_API void cosx_tilde_setup(void)
 {
     cosx_class = class_new(gensym("cosx~"), (t_newmethod)cosx_new, 0,
                            sizeof(t_cosx), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/count.c
+++ b/cyclone_objects/binaries/audio/count.c
@@ -5,6 +5,7 @@
 //updating argument parsing on object creation and adding autoreset attribute - Derek Kwan 2016
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define COUNTMAXINT 0x7fffffff
 
@@ -231,7 +232,7 @@ static void *count_new(t_symbol *s, int argc, t_atom *argv)
     return NULL;
 }
 
-void count_tilde_setup(void)
+CYCLONE_OBJ_API void count_tilde_setup(void)
 {
     count_class = class_new(gensym("count~"), (t_newmethod)count_new,
         0, sizeof(t_count), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/cross.c
+++ b/cyclone_objects/binaries/audio/cross.c
@@ -1,6 +1,7 @@
 // Porres 2016
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 
 #define PI M_PI
@@ -147,7 +148,7 @@ static void *cross_new(t_floatarg f)
     return (x);
 }
 
-void cross_tilde_setup(void)
+CYCLONE_OBJ_API void cross_tilde_setup(void)
 {
     cross_class = class_new(gensym("cross~"), (t_newmethod)cross_new, 0,
         sizeof(t_cross), CLASS_DEFAULT, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/audio/curve.c
+++ b/cyclone_objects/binaries/audio/curve.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 /* CHECKED apparently c74's formula has not been carefully tuned (yet?).
    It has 5% deviation from the straight line for ccinput = 0 at half-domain,
@@ -457,7 +458,7 @@ static void *curve_new(t_symbol *s, int argc, t_atom *argv)
 		return NULL;
 }
 
-void curve_tilde_setup(void)
+CYCLONE_OBJ_API void curve_tilde_setup(void)
 {
     curve_class = class_new(gensym("curve~"),
 			    (t_newmethod)curve_new,

--- a/cyclone_objects/binaries/audio/cycle.c
+++ b/cyclone_objects/binaries/audio/cycle.c
@@ -6,6 +6,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include "m_pd.h"
+#include <common/api.h>
 //#include "cybuf.h"
 
 #define CYCYCLE_FREQ 	0
@@ -559,7 +560,7 @@ static void *cycle_free(t_cycle *x)
 	return (void *)x;
 }
 
-void cycle_tilde_setup(void)
+CYCLONE_OBJ_API void cycle_tilde_setup(void)
 {    
     cycle_class = class_new(gensym("cycle~"), (t_newmethod)cycle_new, (t_method)cycle_free,
         sizeof(t_cycle), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/dbtoa.c
+++ b/cyclone_objects/binaries/audio/dbtoa.c
@@ -9,6 +9,7 @@
   Evan Parker Electro-Acoustic Ensemble -- Hasselt
 */
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 
 static t_class *dbtoa_class;
@@ -44,8 +45,7 @@ static void *dbtoa_new(void)
   return (void *)x;
 }
 
-
-void dbtoa_tilde_setup(void) {
+CYCLONE_OBJ_API void dbtoa_tilde_setup(void) {
   dbtoa_class = class_new(gensym("dbtoa~"),
 			  (t_newmethod) dbtoa_new,
 			  0,

--- a/cyclone_objects/binaries/audio/degrade.c
+++ b/cyclone_objects/binaries/audio/degrade.c
@@ -1,6 +1,7 @@
 // Porres 2016
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 
 #define SR_DEF 1.f
@@ -91,8 +92,7 @@ static void *degrade_new(t_symbol *s, int argc, t_atom *argv){ //two optional ar
     return (x);
 }
 
-
-void degrade_tilde_setup(void)
+CYCLONE_OBJ_API void degrade_tilde_setup(void)
 {
     degrade_class = class_new(gensym("degrade~"), (t_newmethod)degrade_new, (t_method)degrade_free,
             sizeof(t_degrade), CLASS_DEFAULT, A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/delay.c
+++ b/cyclone_objects/binaries/audio/delay.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 #include <string.h>
 
@@ -316,7 +317,7 @@ static void delay_free(t_delay *x)
     if (x->x_buf != x->x_bufini) freebytes(x->x_buf, x->x_maxsofar * sizeof(*x->x_buf));
 }
 
-void delay_tilde_setup(void)
+CYCLONE_OBJ_API void delay_tilde_setup(void)
 {
     delay_class = class_new(gensym("delay~"),
 			    (t_newmethod)delay_new, (t_method)delay_free,

--- a/cyclone_objects/binaries/audio/delta.c
+++ b/cyclone_objects/binaries/audio/delta.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _delta
 {
@@ -44,7 +45,7 @@ static void *delta_new(void)
     return (x);
 }
 
-void delta_tilde_setup(void)
+CYCLONE_OBJ_API void delta_tilde_setup(void)
 {
     delta_class = class_new(gensym("delta~"),
 			    (t_newmethod)delta_new, 0,

--- a/cyclone_objects/binaries/audio/deltaclip.c
+++ b/cyclone_objects/binaries/audio/deltaclip.c
@@ -4,6 +4,7 @@
 //updated 2016 by Derek Kwan
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define DELTACLIP_DEFLO  0.
 #define DELTACLIP_DEFHI  0.
@@ -107,7 +108,7 @@ static void *deltaclip_new(t_symbol *s, int argc, t_atom *argv)
 		return NULL;
 }
 
-void deltaclip_tilde_setup(void)
+CYCLONE_OBJ_API void deltaclip_tilde_setup(void)
 {
     deltaclip_class = class_new(gensym("deltaclip~"),
 				(t_newmethod)deltaclip_new,

--- a/cyclone_objects/binaries/audio/downsamp.c
+++ b/cyclone_objects/binaries/audio/downsamp.c
@@ -1,6 +1,7 @@
 // Porres 2016
 
 #include "m_pd.h"
+#include <common/api.h>
 
 static t_class *downsamp_class;
 
@@ -60,8 +61,7 @@ static void *downsamp_new(t_floatarg f)
     return (x);
 }
 
-
-void downsamp_tilde_setup(void)
+CYCLONE_OBJ_API void downsamp_tilde_setup(void)
 {
     downsamp_class = class_new(gensym("downsamp~"),
         (t_newmethod)downsamp_new,

--- a/cyclone_objects/binaries/audio/edge.c
+++ b/cyclone_objects/binaries/audio/edge.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _edge
 {
@@ -95,7 +96,7 @@ static void *edge_new(void)
     return (x);
 }
 
-void edge_tilde_setup(void)
+CYCLONE_OBJ_API void edge_tilde_setup(void)
 {
     edge_class = class_new(gensym("edge~"),
 			   (t_newmethod)edge_new,

--- a/cyclone_objects/binaries/audio/equals.c
+++ b/cyclone_objects/binaries/audio/equals.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Porres.
 
 #include "m_pd.h"
+#include <common/api.h>
 
 static t_class *equals_class;
 
@@ -47,7 +48,7 @@ static void *equals_new(t_floatarg f)
     return (x);
 }
 
-void equals_tilde_setup(void)
+CYCLONE_OBJ_API void equals_tilde_setup(void)
 {
     equals_class = class_new(gensym("equals~"),
             (t_newmethod)equals_new,

--- a/cyclone_objects/binaries/audio/frameaccum.c
+++ b/cyclone_objects/binaries/audio/frameaccum.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define FRAMEACCUM_INISIZE  512
@@ -75,7 +76,7 @@ static void *frameaccum_new(t_floatarg f)
     return (x);
 }
 
-void frameaccum_tilde_setup(void)
+CYCLONE_OBJ_API void frameaccum_tilde_setup(void)
 {
     frameaccum_class = class_new(gensym("frameaccum~"),
 				 (t_newmethod)frameaccum_new,

--- a/cyclone_objects/binaries/audio/framedelta.c
+++ b/cyclone_objects/binaries/audio/framedelta.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define FRAMEDELTA_INISIZE  512
@@ -66,7 +67,7 @@ static void *framedelta_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void framedelta_tilde_setup(void)
+CYCLONE_OBJ_API void framedelta_tilde_setup(void)
 {
     framedelta_class = class_new(gensym("framedelta~"),
 				 (t_newmethod)framedelta_new,

--- a/cyclone_objects/binaries/audio/gate.c
+++ b/cyclone_objects/binaries/audio/gate.c
@@ -1,6 +1,7 @@
 // based on selector~
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 //#include <math.h>
 
@@ -134,7 +135,7 @@ static void *gate_new(t_symbol *s, int argc, t_atom *argv)
     return (x);
 }
 
-void gate_tilde_setup(void)
+CYCLONE_OBJ_API void gate_tilde_setup(void)
 {
     gate_class = class_new(gensym("gate~"), (t_newmethod)gate_new, 0,
             sizeof(t_gate), CLASS_DEFAULT, A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/greaterthan.c
+++ b/cyclone_objects/binaries/audio/greaterthan.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Porres.
 
 #include "m_pd.h"
+#include <common/api.h>
 
 // ---------------------------------------------------
 // Class definition
@@ -65,7 +66,7 @@ static void *greaterthan_new(t_floatarg f)
 // ---------------------------------------------------
 // Setup
 // ---------------------------------------------------
-void greaterthan_tilde_setup(void)
+CYCLONE_OBJ_API void greaterthan_tilde_setup(void)
 {
     greaterthan_class = class_new(gensym("greaterthan~"),
                              (t_newmethod)greaterthan_new,

--- a/cyclone_objects/binaries/audio/greaterthaneq.c
+++ b/cyclone_objects/binaries/audio/greaterthaneq.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Porres.
 
 #include "m_pd.h"
+#include <common/api.h>
 
 // ---------------------------------------------------
 // Class definition
@@ -65,7 +66,7 @@ static void *greaterthaneq_new(t_floatarg f)
 // ---------------------------------------------------
 // Setup
 // ---------------------------------------------------
-void greaterthaneq_tilde_setup(void)
+CYCLONE_OBJ_API void greaterthaneq_tilde_setup(void)
 {
     greaterthaneq_class = class_new(gensym("greaterthaneq~"),
                                   (t_newmethod)greaterthaneq_new,

--- a/cyclone_objects/binaries/audio/index.c
+++ b/cyclone_objects/binaries/audio/index.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "signal/cybuf.h"
 
 #define INDEX_MAXCHANNELS  64
@@ -98,7 +99,7 @@ static void *index_new(t_symbol *s, t_floatarg f)
     return (x);
 }
 
-void index_tilde_setup(void)
+CYCLONE_OBJ_API void index_tilde_setup(void)
 {
     index_class = class_new(gensym("index~"),
 			    (t_newmethod)index_new,

--- a/cyclone_objects/binaries/audio/kink.c
+++ b/cyclone_objects/binaries/audio/kink.c
@@ -10,6 +10,7 @@
    UPDATE 02/17 - used the "magic trick" to fix this -- MB */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 
 static t_class *kink_class;
@@ -88,7 +89,7 @@ static void *kink_new(t_floatarg f)
     return (x);
 }
 
-void kink_tilde_setup(void)
+CYCLONE_OBJ_API void kink_tilde_setup(void)
 {
     kink_class = class_new(gensym("kink~"),
 			   (t_newmethod)kink_new, 0,

--- a/cyclone_objects/binaries/audio/lessthan.c
+++ b/cyclone_objects/binaries/audio/lessthan.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Porres.
 
 #include "m_pd.h"
+#include <common/api.h>
 
 // ---------------------------------------------------
 // Class definition
@@ -65,7 +66,7 @@ static void *lessthan_new(t_floatarg f)
 // ---------------------------------------------------
 // Setup
 // ---------------------------------------------------
-void lessthan_tilde_setup(void)
+CYCLONE_OBJ_API void lessthan_tilde_setup(void)
 {
     lessthan_class = class_new(gensym("lessthan~"),
                                   (t_newmethod)lessthan_new,

--- a/cyclone_objects/binaries/audio/lessthaneq.c
+++ b/cyclone_objects/binaries/audio/lessthaneq.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Porres.
 
 #include "m_pd.h"
+#include <common/api.h>
 
 // ---------------------------------------------------
 // Class definition
@@ -65,7 +66,7 @@ static void *lessthaneq_new(t_floatarg f)
 // ---------------------------------------------------
 // Setup
 // ---------------------------------------------------
-void lessthaneq_tilde_setup(void)
+CYCLONE_OBJ_API void lessthaneq_tilde_setup(void)
 {
     lessthaneq_class = class_new(gensym("lessthaneq~"),
                                (t_newmethod)lessthaneq_new,

--- a/cyclone_objects/binaries/audio/line.c
+++ b/cyclone_objects/binaries/audio/line.c
@@ -4,7 +4,8 @@
 
 // Added code for the stop, pause and resume messages, fjkraan, 2014-12-02 (alpha57)
 
-#include "m_pd.h"'
+#include "m_pd.h"
+#include <common/api.h>
 
 #define LINE_MAX_SIZE  128
 
@@ -256,7 +257,7 @@ static void *line_new(t_floatarg f)
     return (x);
 }
 
-void line_tilde_setup(void)
+CYCLONE_OBJ_API void line_tilde_setup(void)
 {
     line_class = class_new(gensym("Line~"),  // avoid name clash with vanilla
         (t_newmethod)line_new, (t_method)line_free, sizeof(t_line), 0, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/audio/lookup.c
+++ b/cyclone_objects/binaries/audio/lookup.c
@@ -1,6 +1,7 @@
 //old code scrapped, brand new code by Derek Kwan - 2016
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 #include "signal/cybuf.h"
 
@@ -196,8 +197,7 @@ static void *lookup_free(t_lookup *x)
 	return (void *)x;
 }
 
-
-void lookup_tilde_setup(void)
+CYCLONE_OBJ_API void lookup_tilde_setup(void)
 {
    lookup_class = class_new(gensym("lookup~"),
 			     (t_newmethod)lookup_new,

--- a/cyclone_objects/binaries/audio/lores.c
+++ b/cyclone_objects/binaries/audio/lores.c
@@ -9,6 +9,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 /* CHECKME negative loresance */
 /* CHECKME max loresance, esp. at low freqs (watch out, gain not normalized) */
@@ -95,7 +96,7 @@ static void *lores_new(t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void lores_tilde_setup(void)
+CYCLONE_OBJ_API void lores_tilde_setup(void)
 {
     lores_class = class_new(gensym("lores~"),
 			    (t_newmethod)lores_new, 0,

--- a/cyclone_objects/binaries/audio/matrix.c
+++ b/cyclone_objects/binaries/audio/matrix.c
@@ -19,6 +19,7 @@ changed matrix_free to return void * instead of nothing
 #include <string.h>
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 
 #define MATRIX_DEFGAIN  0.  /* CHECKED */
@@ -689,7 +690,7 @@ static void *matrix_new(t_symbol *s, int argc, t_atom *argv)
 		return NULL;
 }
 
-void matrix_tilde_setup(void)
+CYCLONE_OBJ_API void matrix_tilde_setup(void)
 {
     matrix_class = class_new(gensym("matrix~"),
 			     (t_newmethod)matrix_new,

--- a/cyclone_objects/binaries/audio/maximum.c
+++ b/cyclone_objects/binaries/audio/maximum.c
@@ -5,6 +5,7 @@
 // LATER use hasfeeders (why?)
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _maximum {
     t_object    x_obj;
@@ -46,7 +47,7 @@ static void *maximum_new(t_floatarg f)
     return (x);
 }
 
-void maximum_tilde_setup(void)
+CYCLONE_OBJ_API void maximum_tilde_setup(void)
 {
     maximum_class = class_new(gensym("maximum~"),
                               (t_newmethod)maximum_new, 0,

--- a/cyclone_objects/binaries/audio/minimum.c
+++ b/cyclone_objects/binaries/audio/minimum.c
@@ -5,6 +5,7 @@
 // LATER use hasfeeders (why?)
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _minimum {
     t_object    x_obj;
@@ -46,7 +47,7 @@ static void *minimum_new(t_floatarg f)
     return (x);
 }
 
-void minimum_tilde_setup(void)
+CYCLONE_OBJ_API void minimum_tilde_setup(void)
 {
     minimum_class = class_new(gensym("minimum~"),
 			      (t_newmethod)minimum_new, 0,

--- a/cyclone_objects/binaries/audio/minmax.c
+++ b/cyclone_objects/binaries/audio/minmax.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 #include "common/magicbit.h"
 
@@ -128,7 +129,7 @@ static void *minmax_new(void)
     return (x);
 }
 
-void minmax_tilde_setup(void)
+CYCLONE_OBJ_API void minmax_tilde_setup(void)
 {
     minmax_class = class_new(gensym("minmax~"),
         (t_newmethod)minmax_new, 0, sizeof(t_minmax), 0, 0);

--- a/cyclone_objects/binaries/audio/modulo.c
+++ b/cyclone_objects/binaries/audio/modulo.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Porres.
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "math.h"
 
 // ---------------------------------------------------
@@ -66,7 +67,7 @@ static void *modulo_new(t_floatarg f)
 // ---------------------------------------------------
 // Setup
 // ---------------------------------------------------
-void modulo_tilde_setup(void)
+CYCLONE_OBJ_API void modulo_tilde_setup(void)
 {
     modulo_class = class_new(gensym("modulo~"),
                              (t_newmethod)modulo_new,

--- a/cyclone_objects/binaries/audio/mstosamps.c
+++ b/cyclone_objects/binaries/audio/mstosamps.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _mstosamps
 {
@@ -48,7 +49,7 @@ static void *mstosamps_new(void)
     return (x);
 }
 
-void mstosamps_tilde_setup(void)
+CYCLONE_OBJ_API void mstosamps_tilde_setup(void)
 {
     mstosamps_class = class_new(gensym("mstosamps~"),
             (t_newmethod)mstosamps_new, 0, sizeof(t_mstosamps),

--- a/cyclone_objects/binaries/audio/notequals.c
+++ b/cyclone_objects/binaries/audio/notequals.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Porres.
 
 #include "m_pd.h"
+#include <common/api.h>
 
 // ---------------------------------------------------
 // Class definition
@@ -65,7 +66,7 @@ static void *notequals_new(t_floatarg f)
 // ---------------------------------------------------
 // Setup
 // ---------------------------------------------------
-void notequals_tilde_setup(void)
+CYCLONE_OBJ_API void notequals_tilde_setup(void)
 {
     notequals_class = class_new(gensym("notequals~"),
                              (t_newmethod)notequals_new,

--- a/cyclone_objects/binaries/audio/onepole.c
+++ b/cyclone_objects/binaries/audio/onepole.c
@@ -9,6 +9,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define ONEPOLE_HZ        0
 #define ONEPOLE_LINEAR    1
@@ -145,8 +146,7 @@ static void *onepole_new(t_symbol *s, int ac, t_atom *av)
 }
 
 // anything for hz?
-
-void onepole_tilde_setup(void)
+CYCLONE_OBJ_API void onepole_tilde_setup(void)
 {
     ps_hz = gensym("hz");
     ps_linear = gensym("linear");

--- a/cyclone_objects/binaries/audio/overdrive.c
+++ b/cyclone_objects/binaries/audio/overdrive.c
@@ -6,6 +6,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _overdrive
 {
@@ -73,7 +74,7 @@ static void *overdrive_new(t_floatarg f)
     return (x);
 }
 
-void overdrive_tilde_setup(void)
+CYCLONE_OBJ_API void overdrive_tilde_setup(void)
 {
     overdrive_class = class_new(gensym("overdrive~"),
 				(t_newmethod)overdrive_new, (t_method)overdrive_free,

--- a/cyclone_objects/binaries/audio/peakamp.c
+++ b/cyclone_objects/binaries/audio/peakamp.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _peakamp
 {
@@ -93,7 +94,7 @@ static void *peakamp_new(t_floatarg f)
     return (x);
 }
 
-void peakamp_tilde_setup(void)
+CYCLONE_OBJ_API void peakamp_tilde_setup(void)
 {
     peakamp_class = class_new(gensym("peakamp~"),
 			      (t_newmethod)peakamp_new,

--- a/cyclone_objects/binaries/audio/peek.c
+++ b/cyclone_objects/binaries/audio/peek.c
@@ -6,6 +6,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "signal/cybuf.h"
 #define PEEK_MAXCHANNELS  64  /* LATER implement arsic resizing feature */
 #define PEEK_TICK_TIME  2  //
@@ -132,7 +133,7 @@ static void *peek_new(t_symbol *s, t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void peek_tilde_setup(void)
+CYCLONE_OBJ_API void peek_tilde_setup(void)
 {
     peek_class = class_new(gensym("peek~"),
 			   (t_newmethod)peek_new,

--- a/cyclone_objects/binaries/audio/phaseshift.c
+++ b/cyclone_objects/binaries/audio/phaseshift.c
@@ -1,6 +1,7 @@
 // Porres 2016
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 
 #define PI M_PI
@@ -84,7 +85,7 @@ static void *phaseshift_new(t_floatarg f1, t_floatarg f2){
     return (x);
 }
 
-void phaseshift_tilde_setup(void){
+CYCLONE_OBJ_API void phaseshift_tilde_setup(void){
     phaseshift_class = class_new(gensym("phaseshift~"), (t_newmethod)phaseshift_new, 0,
         sizeof(t_phaseshift), CLASS_DEFAULT, A_DEFFLOAT, A_DEFFLOAT, 0);
     class_addmethod(phaseshift_class, (t_method)phaseshift_dsp, gensym("dsp"), A_CANT, 0);

--- a/cyclone_objects/binaries/audio/phasewrap.c
+++ b/cyclone_objects/binaries/audio/phasewrap.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/shared.h"
 
 typedef struct _phasewrap
@@ -116,7 +117,7 @@ static void *phasewrap_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void phasewrap_tilde_setup(void)
+CYCLONE_OBJ_API void phasewrap_tilde_setup(void)
 {
     phasewrap_class = class_new(gensym("phasewrap~"),
 				(t_newmethod)phasewrap_new, 0,

--- a/cyclone_objects/binaries/audio/pink.c
+++ b/cyclone_objects/binaries/audio/pink.c
@@ -9,6 +9,7 @@
 // Max has a dummy signal in (needed for begin~)
 
 #include "m_pd.h"
+#include <common/api.h>
 
 /* more like 0.085 in c74's */
 #define PINK_GAIN  .105
@@ -85,7 +86,7 @@ static void *pink_new(void)
     return (x);
 }
 
-void pink_tilde_setup(void)
+CYCLONE_OBJ_API void pink_tilde_setup(void)
 {
     pink_class = class_new(gensym("pink~"),
 			   (t_newmethod)pink_new, 0,

--- a/cyclone_objects/binaries/audio/play.c
+++ b/cyclone_objects/binaries/audio/play.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "signal/cybuf.h"
 #include "common/magicbit.h"
 #include "common/shared.h"
@@ -692,7 +693,7 @@ static void *play_new(t_symbol * s, int argc, t_atom * argv)
 		return NULL;
 }
 
-void play_tilde_setup(void)
+CYCLONE_OBJ_API void play_tilde_setup(void)
 {
     play_class = class_new(gensym("play~"), (t_newmethod)play_new, (t_method)play_free,
 			   sizeof(t_play), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/plusequals.c
+++ b/cyclone_objects/binaries/audio/plusequals.c
@@ -1,6 +1,7 @@
 // Porres 2016
 
 #include "m_pd.h"
+#include <common/api.h>
 //#include <math.h>
 
 // MAGIC
@@ -120,7 +121,7 @@ static void *plusequals_new(t_floatarg f)
     return (x);
 }
 
-void plusequals_tilde_setup(void)
+CYCLONE_OBJ_API void plusequals_tilde_setup(void)
 {
     plusequals_class = class_new(gensym("plusequals~"), (t_newmethod)plusequals_new,
         0, sizeof(t_plusequals), CLASS_DEFAULT, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/audio/poke.c
+++ b/cyclone_objects/binaries/audio/poke.c
@@ -16,6 +16,7 @@
 */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "signal/cybuf.h"
 
 #define POKE_MAXCHANNELS  64
@@ -188,7 +189,7 @@ static void *poke_new(t_symbol *s, t_floatarg f)
     return (x);
 }
 
-void poke_tilde_setup(void)
+CYCLONE_OBJ_API void poke_tilde_setup(void)
 {
     poke_class = class_new(gensym("poke~"),
 			   (t_newmethod)poke_new,

--- a/cyclone_objects/binaries/audio/poltocar.c
+++ b/cyclone_objects/binaries/audio/poltocar.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 
 typedef struct _poltocar
@@ -73,7 +74,7 @@ static void *poltocar_new(void)
     return (x);
 }
 
-void poltocar_tilde_setup(void)
+CYCLONE_OBJ_API void poltocar_tilde_setup(void)
 {
     poltocar_class = class_new(gensym("poltocar~"),
             (t_newmethod)poltocar_new, 0,

--- a/cyclone_objects/binaries/audio/pong.c
+++ b/cyclone_objects/binaries/audio/pong.c
@@ -1,6 +1,7 @@
 //2016 by Derek Kwan
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 #include <string.h>
 #include <ctype.h>
@@ -305,8 +306,7 @@ errstate:
     return NULL;
 }
 
-
-void pong_tilde_setup(void){
+CYCLONE_OBJ_API void pong_tilde_setup(void){
 	pong_tilde_class = class_new(gensym("pong~"), (t_newmethod)pong_tilde_new, 0,
 			sizeof(t_pong_tilde), CLASS_DEFAULT, A_GIMME, 0);
 	class_addmethod(pong_tilde_class, (t_method)pong_tilde_setrange, gensym("range"), A_FLOAT, A_FLOAT, 0);

--- a/cyclone_objects/binaries/audio/pow.c
+++ b/cyclone_objects/binaries/audio/pow.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 static t_class *pow_class;
 
@@ -45,7 +46,7 @@ static void *pow_new(t_floatarg f){
     return (x);
 }
 
-void pow_tilde_setup(void){
+CYCLONE_OBJ_API void pow_tilde_setup(void){
     pow_class = class_new(gensym("Pow~"), (t_newmethod)pow_new,
                           (t_method)pow_free, sizeof(t_pow), CLASS_DEFAULT, A_DEFFLOAT, 0);
     class_addcreator((t_newmethod)pow_new, gensym("cyclone/pow~"), A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/rampsmooth.c
+++ b/cyclone_objects/binaries/audio/rampsmooth.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define RAMPSMOOTH_DEFNUP    0.
 #define RAMPSMOOTH_DEFNDOWN  0.
@@ -163,7 +164,7 @@ static void *rampsmooth_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void rampsmooth_tilde_setup(void)
+CYCLONE_OBJ_API void rampsmooth_tilde_setup(void)
 {
     rampsmooth_class = class_new(gensym("rampsmooth~"),
 				 (t_newmethod)rampsmooth_new, 0,

--- a/cyclone_objects/binaries/audio/rand.c
+++ b/cyclone_objects/binaries/audio/rand.c
@@ -5,6 +5,7 @@
 /* This is a compilation of phasor~ and noise~ code from d_osc.c. */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/shared.h"
 
 typedef struct _rand
@@ -89,7 +90,7 @@ static void *rand_new(t_floatarg f)
     return (x);
 }
 
-void rand_tilde_setup(void)
+CYCLONE_OBJ_API void rand_tilde_setup(void)
 {
     rand_class = class_new(gensym("rand~"), (t_newmethod)rand_new, 0,
             sizeof(t_rand), CLASS_DEFAULT, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/audio/rdiv.c
+++ b/cyclone_objects/binaries/audio/rdiv.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Porres.
 
 #include "m_pd.h"
+#include <common/api.h>
 
 static t_class *rdiv_class;
 
@@ -46,7 +47,7 @@ static void *rdiv_new(t_floatarg f)
     return (x);
 }
 
-void rdiv_tilde_setup(void)
+CYCLONE_OBJ_API void rdiv_tilde_setup(void)
 {
     rdiv_class = class_new(gensym("rdiv~"), (t_newmethod)rdiv_new,
         (t_method)rdiv_free, sizeof(t_rdiv), CLASS_DEFAULT, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/audio/record.c
+++ b/cyclone_objects/binaries/audio/record.c
@@ -24,6 +24,7 @@ the beginning of the ramp to default to the end of the whole array, right?
  
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "m_imp.h"
 #include "common/shared.h"
 #include "signal/cybuf.h"
@@ -532,7 +533,7 @@ static void *record_new(t_symbol *s, int argc, t_atom *argv)
 		return NULL;
 }
 
-void record_tilde_setup(void)
+CYCLONE_OBJ_API void record_tilde_setup(void)
 {
     record_class = class_new(gensym("record~"),
 			     (t_newmethod)record_new,

--- a/cyclone_objects/binaries/audio/reson.c
+++ b/cyclone_objects/binaries/audio/reson.c
@@ -10,6 +10,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define RESON_DEFQ      .01
 #define RESON_MINQ      1e-20      /* CHECKME */
@@ -111,7 +112,7 @@ static void *reson_new(t_floatarg f1, t_floatarg f2, t_floatarg f3)
     return (x);
 }
 
-void reson_tilde_setup(void)
+CYCLONE_OBJ_API void reson_tilde_setup(void)
 {
     reson_class = class_new(gensym("reson~"),
 			    (t_newmethod)reson_new, 0,

--- a/cyclone_objects/binaries/audio/rminus.c
+++ b/cyclone_objects/binaries/audio/rminus.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Porres.
 
 #include "m_pd.h"
+#include <common/api.h>
 
 // ---------------------------------------------------
 // Class definition
@@ -65,7 +66,7 @@ static void *rminus_new(t_floatarg f)
 // ---------------------------------------------------
 // Setup
 // ---------------------------------------------------
-void rminus_tilde_setup(void)
+CYCLONE_OBJ_API void rminus_tilde_setup(void)
 {
     rminus_class = class_new(gensym("rminus~"),
                            (t_newmethod)rminus_new,

--- a/cyclone_objects/binaries/audio/round.c
+++ b/cyclone_objects/binaries/audio/round.c
@@ -1,6 +1,7 @@
 //2016 by Derek Kwan
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 #include <string.h>
 #include <ctype.h>
@@ -129,7 +130,7 @@ static void round_tilde_dsp(t_round_tilde *x, t_signal **sp)
 	dsp_add(round_tilde_perform, 5, x, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
 }
 
-void round_tilde_setup(void)
+CYCLONE_OBJ_API void round_tilde_setup(void)
 {
 	round_tilde_class = class_new(gensym("round~"), (t_newmethod)round_tilde_new, 0,
 	sizeof(t_round_tilde), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/sah.c
+++ b/cyclone_objects/binaries/audio/sah.c
@@ -4,6 +4,7 @@
 
 
 #include "m_pd.h"
+#include <common/api.h>
 // MAGIC: include magicbit.h for magic
 #include "common/magicbit.h"
 // end magic
@@ -109,7 +110,7 @@ static void *sah_new(t_floatarg f)
     return (x);
 }
 
-void sah_tilde_setup(void)
+CYCLONE_OBJ_API void sah_tilde_setup(void)
 {
     sah_class = class_new(gensym("sah~"), (t_newmethod)sah_new, 0,
                         sizeof(t_sah), CLASS_DEFAULT, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/audio/sampstoms.c
+++ b/cyclone_objects/binaries/audio/sampstoms.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _sampstoms
 {
@@ -49,7 +50,7 @@ static void *sampstoms_new(void)
     return (x);
 }
 
-void sampstoms_tilde_setup(void)
+CYCLONE_OBJ_API void sampstoms_tilde_setup(void)
 {
     sampstoms_class = class_new(gensym("sampstoms~"),
         (t_newmethod)sampstoms_new, 0, sizeof(t_sampstoms), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/scale.c
+++ b/cyclone_objects/binaries/audio/scale.c
@@ -1,6 +1,7 @@
 // Porres 2016
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 #include <string.h>
 
@@ -175,7 +176,7 @@ static void *scale_new(t_symbol *s, int argc, t_atom *argv)
 		return NULL;
 }
 
-void scale_tilde_setup(void)
+CYCLONE_OBJ_API void scale_tilde_setup(void)
 {
     scale_class = class_new(gensym("scale~"),
 				(t_newmethod)scale_new,

--- a/cyclone_objects/binaries/audio/scope.c
+++ b/cyclone_objects/binaries/audio/scope.c
@@ -22,6 +22,7 @@
 // 2017 = Porres finished cleaning "sickle/sic, loud, fitter & forky" dependencies
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "g_canvas.h"
 #include "g_all_guis.h"
 #include "common/magicbit.h"
@@ -2225,7 +2226,7 @@ errstate:
     return NULL;
 }
 
-void scope_tilde_setup(void){
+CYCLONE_OBJ_API void scope_tilde_setup(void){
     scope_class = class_new(gensym("scope~"), (t_newmethod)scope_new,
                             (t_method)scope_free, sizeof(t_scope), 0, A_GIMME, 0);
     class_addcreator((t_newmethod)scope_new,

--- a/cyclone_objects/binaries/audio/selector.c
+++ b/cyclone_objects/binaries/audio/selector.c
@@ -1,6 +1,7 @@
 // Derek Kwan - 2016
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 //#include <math.h>
 
@@ -147,7 +148,7 @@ void * selector_free(t_selector *x){
          return (void *) x;
 }
 
-void selector_tilde_setup(void)
+CYCLONE_OBJ_API void selector_tilde_setup(void)
 {
     selector_class = class_new(gensym("selector~"), (t_newmethod)selector_new, (t_method)selector_free,
             sizeof(t_selector), CLASS_DEFAULT, A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/sinh.c
+++ b/cyclone_objects/binaries/audio/sinh.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _sinh {
     t_object x_obj;
@@ -42,7 +43,7 @@ void *sinh_new(void)
     return (x);
 }
 
-void sinh_tilde_setup(void)
+CYCLONE_OBJ_API void sinh_tilde_setup(void)
 {
     sinh_class = class_new(gensym("sinh~"), (t_newmethod)sinh_new, 0,
                            sizeof(t_sinh), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/sinx.c
+++ b/cyclone_objects/binaries/audio/sinx.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _sinx {
     t_object x_obj;
@@ -42,7 +43,7 @@ void *sinx_new(void)
     return (x);
 }
 
-void sinx_tilde_setup(void)
+CYCLONE_OBJ_API void sinx_tilde_setup(void)
 {
     sinx_class = class_new(gensym("sinx~"), (t_newmethod)sinx_new, 0,
                            sizeof(t_sinx), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/slide.c
+++ b/cyclone_objects/binaries/audio/slide.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define SLIDE_DEFUP  1.
 #define SLIDE_DEFDN  1.
@@ -108,7 +109,7 @@ static void *slide_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void slide_tilde_setup(void)
+CYCLONE_OBJ_API void slide_tilde_setup(void)
 {
     slide_class = class_new(gensym("slide~"),
 			    (t_newmethod)slide_new, 0,

--- a/cyclone_objects/binaries/audio/snapshot.c
+++ b/cyclone_objects/binaries/audio/snapshot.c
@@ -6,6 +6,7 @@
 //updating argument parsing for object creation, adding interval and active attributes - Derek Kwan 2016
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 /* CHECKME for a fixed minimum deltime, if any (5ms for c74's metro) */
 
@@ -213,7 +214,7 @@ static void *snapshot_new(t_symbol *s, int argc, t_atom * argv)
 		return NULL;
 }
 
-void snapshot_tilde_setup(void)
+CYCLONE_OBJ_API void snapshot_tilde_setup(void)
 {
     snapshot_class = class_new(gensym("Snapshot~"),
         (t_newmethod)snapshot_new, (t_method)snapshot_free, sizeof(t_snapshot), 0, A_GIMME,0);

--- a/cyclone_objects/binaries/audio/spike.c
+++ b/cyclone_objects/binaries/audio/spike.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _spike
 {
@@ -102,7 +103,7 @@ static void *spike_new(t_floatarg f)
     return (x);
 }
 
-void spike_tilde_setup(void)
+CYCLONE_OBJ_API void spike_tilde_setup(void)
 {
     spike_class = class_new(gensym("spike~"),
 			    (t_newmethod)spike_new,

--- a/cyclone_objects/binaries/audio/svf.c
+++ b/cyclone_objects/binaries/audio/svf.c
@@ -11,6 +11,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define SVF_HZ        0
 #define SVF_LINEAR    1
@@ -173,7 +174,7 @@ static void *svf_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void svf_tilde_setup(void)
+CYCLONE_OBJ_API void svf_tilde_setup(void)
 {
     ps_hz = gensym("hz");
     ps_linear = gensym("linear");

--- a/cyclone_objects/binaries/audio/tanh.c
+++ b/cyclone_objects/binaries/audio/tanh.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _tanh {
     t_object x_obj;
@@ -42,7 +43,7 @@ void *tanh_new(void)
     return (x);
 }
 
-void tanh_tilde_setup(void)
+CYCLONE_OBJ_API void tanh_tilde_setup(void)
 {
     tanh_class = class_new(gensym("tanh~"), (t_newmethod)tanh_new, 0,
                            sizeof(t_tanh), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/tanx.c
+++ b/cyclone_objects/binaries/audio/tanx.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _tanx {
     t_object x_obj;
@@ -42,7 +43,7 @@ void *tanx_new(void)
     return (x);
 }
 
-void tanx_tilde_setup(void)
+CYCLONE_OBJ_API void tanx_tilde_setup(void)
 {
     tanx_class = class_new(gensym("tanx~"), (t_newmethod)tanx_new, 0,
                            sizeof(t_tanx), CLASS_DEFAULT, 0);

--- a/cyclone_objects/binaries/audio/teeth.c
+++ b/cyclone_objects/binaries/audio/teeth.c
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define TEETH_STACK 48000 //stack buf size, 1 sec at 48k for good measure
 #define TEETH_DELAY  10.0 //maximum delay
@@ -364,7 +365,7 @@ static void * teeth_free(t_teeth *x){
     return (void *)x;
 }
 
-void teeth_tilde_setup(void)
+CYCLONE_OBJ_API void teeth_tilde_setup(void)
 {
     teeth_class = class_new(gensym("teeth~"),
 			   (t_newmethod)teeth_new,

--- a/cyclone_objects/binaries/audio/thresh.c
+++ b/cyclone_objects/binaries/audio/thresh.c
@@ -3,6 +3,7 @@
 * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define THRESH_DEFLO  0.
 #define THRESH_DEFHI  0.
@@ -96,7 +97,7 @@ static void *thresh_new(t_symbol *s, int argc, t_atom *argv)
     
 }
 
-void thresh_tilde_setup(void)
+CYCLONE_OBJ_API void thresh_tilde_setup(void)
 {
     thresh_class = class_new(gensym("thresh~"),
         (t_newmethod)thresh_new,

--- a/cyclone_objects/binaries/audio/train.c
+++ b/cyclone_objects/binaries/audio/train.c
@@ -5,6 +5,7 @@
 // fixed and rewritten by Porres
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define TRAIN_DEFPERIOD  1000
 #define TRAIN_DEFWIDTH   0.5
@@ -146,7 +147,7 @@ errstate:
     return NULL;
 }
 
-void train_tilde_setup(void)
+CYCLONE_OBJ_API void train_tilde_setup(void)
 {
     train_class = class_new(gensym("train~"), (t_newmethod)train_new,
             (t_method)train_free, sizeof(t_train), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/audio/trapezoid.c
+++ b/cyclone_objects/binaries/audio/trapezoid.c
@@ -5,6 +5,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define TRAPEZOID_DEFUP  0.1  
 #define TRAPEZOID_DEFDN  0.9  
@@ -164,7 +165,7 @@ void *trapezoid_free(t_trapezoid *x){
 	return (void *)x;
 }
 
-void trapezoid_tilde_setup(void)
+CYCLONE_OBJ_API void trapezoid_tilde_setup(void)
 {
     trapezoid_class = class_new(gensym("trapezoid~"),
 				(t_newmethod)trapezoid_new, (t_method)trapezoid_free,

--- a/cyclone_objects/binaries/audio/triangle.c
+++ b/cyclone_objects/binaries/audio/triangle.c
@@ -5,6 +5,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define TRIANGLE_DEFPEAK 	0.5
 #define TRIANGLE_DEFLO    	-1.0
@@ -152,8 +153,7 @@ void *triangle_free(t_triangle *x){
 }
 
 
-
-void triangle_tilde_setup(void)
+CYCLONE_OBJ_API void triangle_tilde_setup(void)
 {
     triangle_class = class_new(gensym("triangle~"),
 			       (t_newmethod)triangle_new, (t_method)triangle_free,

--- a/cyclone_objects/binaries/audio/trunc.c
+++ b/cyclone_objects/binaries/audio/trunc.c
@@ -1,5 +1,6 @@
 /* code generated thanks to Schiavoni's Pure Data external Generator */
 #include "m_pd.h"
+#include <common/api.h>
 #include "math.h"
 
 // ---------------------------------------------------
@@ -70,7 +71,7 @@ void trunc_destroy(t_trunc *x)
 // ---------------------------------------------------
 // Setup
 // ---------------------------------------------------
-void trunc_tilde_setup(void) {
+CYCLONE_OBJ_API void trunc_tilde_setup(void) {
    trunc_class = class_new(gensym("trunc~"),
       (t_newmethod) trunc_new, // Constructor
       (t_method) trunc_destroy, // Destructor

--- a/cyclone_objects/binaries/audio/typeroute.c
+++ b/cyclone_objects/binaries/audio/typeroute.c
@@ -1,5 +1,6 @@
 
 #include "m_pd.h"
+#include <common/api.h>
 
 
 typedef struct _typeroute
@@ -44,7 +45,7 @@ static void *typeroute_new(void)
     return (x);
 }
 
-void typeroute_tilde_setup(void)
+CYCLONE_OBJ_API void typeroute_tilde_setup(void)
 {
     typeroute_class = class_new(gensym("typeroute~"),
 			    (t_newmethod)typeroute_new,

--- a/cyclone_objects/binaries/audio/vectral.c
+++ b/cyclone_objects/binaries/audio/vectral.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/magicbit.h"
 
 #define VECTRAL_DEFSIZE  512
@@ -250,7 +251,7 @@ failure:
     return (0);
 }
 
-void vectral_tilde_setup(void)
+CYCLONE_OBJ_API void vectral_tilde_setup(void)
 {
     vectral_class = class_new(gensym("vectral~"),
 			      (t_newmethod)vectral_new,

--- a/cyclone_objects/binaries/audio/wave.c
+++ b/cyclone_objects/binaries/audio/wave.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "signal/cybuf.h"
 #include "common/shared.h"
 
@@ -591,8 +592,7 @@ static void *wave_new(t_symbol *s, int argc, t_atom * argv){
 		return NULL;
 	}
 
-
-void wave_tilde_setup(void)
+CYCLONE_OBJ_API void wave_tilde_setup(void)
 {
     wave_class = class_new(gensym("wave~"),
 			   (t_newmethod)wave_new,

--- a/cyclone_objects/binaries/audio/zerox.c
+++ b/cyclone_objects/binaries/audio/zerox.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define ZEROX_DEFVOLUME  1.
 
@@ -67,7 +68,7 @@ static void *zerox_new(t_floatarg f)
     return (x);
 }
 
-void zerox_tilde_setup(void)
+CYCLONE_OBJ_API void zerox_tilde_setup(void)
 {
     zerox_class = class_new(gensym("zerox~"),
 			    (t_newmethod)zerox_new, 0,

--- a/cyclone_objects/binaries/control/accum.c
+++ b/cyclone_objects/binaries/control/accum.c
@@ -6,6 +6,7 @@
    The most important changes are listed in "pd-lib-notes.txt" file.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _accum
 {
@@ -53,7 +54,7 @@ static void *accum_new(t_floatarg val)
     return (x);
 }
 
-void accum_setup(void)
+CYCLONE_OBJ_API void accum_setup(void)
 {
     accum_class = class_new(gensym("accum"), (t_newmethod)accum_new, 0,
 			    sizeof(t_accum), 0, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/control/acos.c
+++ b/cyclone_objects/binaries/control/acos.c
@@ -6,6 +6,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _acos
 {
@@ -33,7 +34,7 @@ static void *acos_new(t_floatarg f)
     return (x);
 }
 
-void acos_setup(void)
+CYCLONE_OBJ_API void acos_setup(void)
 {
     acos_class = class_new(gensym("acos"), (t_newmethod)acos_new, 0,
 			   sizeof(t_acos), 0, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/control/acosh.c
+++ b/cyclone_objects/binaries/control/acosh.c
@@ -2,6 +2,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _acosh
 {
@@ -31,7 +32,7 @@ static void *acosh_new(t_floatarg f)
     return (x);
 }
 
-void acosh_setup(void)
+CYCLONE_OBJ_API void acosh_setup(void)
 {
     acosh_class = class_new(gensym("acosh"), (t_newmethod)acosh_new, 0,
 			   sizeof(t_acosh), 0, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/control/active.c
+++ b/cyclone_objects/binaries/control/active.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "control/gui.h"
 
 typedef struct _active{
@@ -41,7 +42,7 @@ static void *active_new(void){
     return (x);
 }
 
-void active_setup(void){
+CYCLONE_OBJ_API void active_setup(void){
     active_class = class_new(gensym("active"), (t_newmethod)active_new,
         (t_method)active_free, sizeof(t_active), CLASS_NOINLET, 0);
     class_addmethod(active_class, (t_method)active_dofocus, gensym("_focus"), A_SYMBOL, A_FLOAT, 0);

--- a/cyclone_objects/binaries/control/anal.c
+++ b/cyclone_objects/binaries/control/anal.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <string.h>
 
 #define ANAL_DEFSIZE  128
@@ -85,7 +86,7 @@ static void *anal_new(t_floatarg f){
     return (x);
 }
 
-void anal_setup(void){
+CYCLONE_OBJ_API void anal_setup(void){
     anal_class = class_new(gensym("anal"), (t_newmethod)anal_new,
             (t_method)anal_free, sizeof(t_anal), 0, A_DEFFLOAT, 0);
     class_addfloat(anal_class, anal_float);

--- a/cyclone_objects/binaries/control/append.c
+++ b/cyclone_objects/binaries/control/append.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define APPEND_INISIZE     32  /* LATER rethink */
@@ -251,7 +252,7 @@ static void *append_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void append_setup(void)
+CYCLONE_OBJ_API void append_setup(void)
 {
     append_class = class_new(gensym("Append"),
         (t_newmethod)append_new, (t_method)append_free, sizeof(t_append), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/control/asin.c
+++ b/cyclone_objects/binaries/control/asin.c
@@ -6,6 +6,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _asin
 {
@@ -33,7 +34,7 @@ static void *asin_new(t_floatarg f)
     return (x);
 }
 
-void asin_setup(void)
+CYCLONE_OBJ_API void asin_setup(void)
 {
     asin_class = class_new(gensym("asin"), (t_newmethod)asin_new, 0,
 			   sizeof(t_asin), 0, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/control/asinh.c
+++ b/cyclone_objects/binaries/control/asinh.c
@@ -2,6 +2,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _asinh
 {
@@ -29,7 +30,7 @@ static void *asinh_new(t_floatarg f) // checked: no protection against NaNs
     return (x);
 }
 
-void asinh_setup(void)
+CYCLONE_OBJ_API void asinh_setup(void)
 {
     asinh_class = class_new(gensym("asinh"),
 			   (t_newmethod)asinh_new, 0,

--- a/cyclone_objects/binaries/control/atanh.c
+++ b/cyclone_objects/binaries/control/atanh.c
@@ -2,6 +2,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _atanh
 {
@@ -29,7 +30,7 @@ static void *atanh_new(t_floatarg f) // checked: no protection against NaNs
     return (x);
 }
 
-void atanh_setup(void)
+CYCLONE_OBJ_API void atanh_setup(void)
 {
     atanh_class = class_new(gensym("atanh"), (t_newmethod)atanh_new, 0,
 			   sizeof(t_atanh), 0, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/control/atodb.c
+++ b/cyclone_objects/binaries/control/atodb.c
@@ -9,6 +9,7 @@
  Disclosure -- Caracal
  */
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 
 static t_class *atodb_class;
@@ -84,7 +85,7 @@ static void atodb_free(t_atodb *x)
   t_freebytes(x->output_list,x->bytes);
 }
 
-void atodb_setup(void)
+CYCLONE_OBJ_API void atodb_setup(void)
 {
   atodb_class = class_new(gensym("atodb"), (t_newmethod)atodb_new,
 			  (t_method)atodb_free,sizeof(t_atodb),0,0);

--- a/cyclone_objects/binaries/control/bangbang.c
+++ b/cyclone_objects/binaries/control/bangbang.c
@@ -6,6 +6,7 @@
    The most important changes are listed in "pd-lib-notes.txt" file.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define BANGBANG_MINOUTS      1
 #define BANGBANG_C74MAXOUTS  40  // CHECKED (just clipped without warning)
@@ -57,7 +58,7 @@ static void *bangbang_new(t_floatarg f){
     return (x);
 }
 
-void bangbang_setup(void){
+CYCLONE_OBJ_API void bangbang_setup(void){
     bangbang_class = class_new(gensym("bangbang"), (t_newmethod)bangbang_new,
         (t_method)bangbang_free, sizeof(t_bangbang), 0, A_DEFFLOAT, 0);
     class_addbang(bangbang_class, bangbang_bang);

--- a/cyclone_objects/binaries/control/bondo.c
+++ b/cyclone_objects/binaries/control/bondo.c
@@ -13,6 +13,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define BONDO_MINSLOTS  2
@@ -384,7 +385,7 @@ static void *bondo_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void bondo_setup(void)
+CYCLONE_OBJ_API void bondo_setup(void)
 {
     bondo_class = class_new(gensym("bondo"),
 			    (t_newmethod)bondo_new,

--- a/cyclone_objects/binaries/control/borax.c
+++ b/cyclone_objects/binaries/control/borax.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define BORAX_MAXVOICES  128  /* CHECKME */
 
@@ -155,7 +156,7 @@ static void *Borax_new(void)
     return (x);
 }
 
-void borax_setup(void)
+CYCLONE_OBJ_API void borax_setup(void)
 {
     Borax_class = class_new(gensym("borax"),
         (t_newmethod)Borax_new, 0, sizeof(t_Borax), 0, 0);

--- a/cyclone_objects/binaries/control/bucket.c
+++ b/cyclone_objects/binaries/control/bucket.c
@@ -6,6 +6,7 @@
    The most important changes are listed in "pd-lib-notes.txt" file.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _Bucket
 {
@@ -120,7 +121,7 @@ static void *Bucket_new(t_floatarg val, t_floatarg max5mode)
     return (x);
 }
 
-void bucket_setup(void)
+CYCLONE_OBJ_API void bucket_setup(void)
 {
     Bucket_class = class_new(gensym("bucket"),
 			     (t_newmethod)Bucket_new,

--- a/cyclone_objects/binaries/control/buddy.c
+++ b/cyclone_objects/binaries/control/buddy.c
@@ -7,6 +7,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define BUDDY_MINSLOTS  2
@@ -231,7 +232,7 @@ static void *buddy_new(t_floatarg f)
     return (x);
 }
 
-void buddy_setup(void)
+CYCLONE_OBJ_API void buddy_setup(void)
 {
     buddy_class = class_new(gensym("buddy"),
 			    (t_newmethod)buddy_new,

--- a/cyclone_objects/binaries/control/capture.c
+++ b/cyclone_objects/binaries/control/capture.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <errno.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/file.h"
 
 #define CAPTURE_DEFSIZE  512
@@ -519,7 +520,7 @@ static void *capture_new(t_symbol *s, int argc, t_atom * argv)
     return (x);
 }
 
-void capture_setup(void)
+CYCLONE_OBJ_API void capture_setup(void)
 {
     capture_class = class_new(gensym("capture"),
 			      (t_newmethod)capture_new,

--- a/cyclone_objects/binaries/control/cartopol.c
+++ b/cyclone_objects/binaries/control/cartopol.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #if defined(_WIN32) || defined(__APPLE__)
 /* cf pd/src/x_arithmetic.c */
@@ -38,7 +39,7 @@ static void *cartopol_new(void){
     return (x);
 }
 
-void cartopol_setup(void){
+CYCLONE_OBJ_API void cartopol_setup(void){
     cartopol_class = class_new(gensym("cartopol"),(t_newmethod)cartopol_new, 0,
 			       sizeof(t_cartopol), 0, 0);
     class_addfloat(cartopol_class, cartopol_float);

--- a/cyclone_objects/binaries/control/clip.c
+++ b/cyclone_objects/binaries/control/clip.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define CLIP_INISIZE   32  /* LATER rethink */
@@ -135,7 +136,7 @@ static void *clip_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void clip_setup(void)
+CYCLONE_OBJ_API void clip_setup(void)
 {
     clip_class = class_new(gensym("Clip"), (t_newmethod)clip_new,
         (t_method)clip_free, sizeof(t_clip), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/control/coll.c
+++ b/cyclone_objects/binaries/control/coll.c
@@ -13,6 +13,7 @@ before used to always bang on callback, now only bangs now due to new x->x_fileb
 #include <stdio.h>
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "g_canvas.h"
 #include "common/file.h"
 
@@ -2287,7 +2288,7 @@ static void *coll_new(t_symbol *s, int argc, t_atom *argv)
 		return NULL;
 }
 
-void coll_setup(void)
+CYCLONE_OBJ_API void coll_setup(void)
 {
     coll_class = class_new(gensym("coll"),
 			   (t_newmethod)coll_new,

--- a/cyclone_objects/binaries/control/comment.c
+++ b/cyclone_objects/binaries/control/comment.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "g_canvas.h"
 
 /* our proxy of the text_class (not in the API), LATER do not cheat */
@@ -960,7 +961,7 @@ textpart:
     return (x);
 }
 
-void comment_setup(void){
+CYCLONE_OBJ_API void comment_setup(void){
     comment_class = class_new(gensym("comment"), (t_newmethod)comment_new,
         (t_method)comment_free, sizeof(t_comment),
         // CLASS_NOINLET | CLASS_PATCHABLE,

--- a/cyclone_objects/binaries/control/cosh.c
+++ b/cyclone_objects/binaries/control/cosh.c
@@ -6,6 +6,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _cosh
 {
@@ -33,7 +34,7 @@ static void *cosh_new(t_floatarg f)
     return (x);
 }
 
-void cosh_setup(void)
+CYCLONE_OBJ_API void cosh_setup(void)
 {
     cosh_class = class_new(gensym("cosh"), (t_newmethod)cosh_new, 0,
 			   sizeof(t_cosh), 0, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/control/counter.c
+++ b/cyclone_objects/binaries/control/counter.c
@@ -16,6 +16,7 @@
 // Adding attributes, p_id, counter_proxy_state, editing existing counter_proxy methods - Derek Kwan 2016
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <string.h>
 
 #define COUNTER_UP      0
@@ -543,7 +544,7 @@ errstate:
     return NULL;
 }
 
-void counter_setup(void)
+CYCLONE_OBJ_API void counter_setup(void)
 {
     counter_class = class_new(gensym("counter"), (t_newmethod)counter_new,
             (t_method)counter_free, sizeof(t_counter), 0,

--- a/cyclone_objects/binaries/control/cycle.c
+++ b/cyclone_objects/binaries/control/cycle.c
@@ -6,6 +6,7 @@
    The most important changes are listed in "pd-lib-notes.txt" file.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 //#define CYCLE_USEEVENTNO
 
@@ -142,7 +143,7 @@ static void *cycle_new(t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void cycle_setup(void){
+CYCLONE_OBJ_API void cycle_setup(void){
     cycle_class = class_new(gensym("cycle"),
 			    (t_newmethod)cycle_new,
 			    (t_method)cycle_free,

--- a/cyclone_objects/binaries/control/dbtoa.c
+++ b/cyclone_objects/binaries/control/dbtoa.c
@@ -6,6 +6,7 @@
  Disclosure -- Caracal
  */
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 
 static t_class *dbtoa_class;
@@ -79,7 +80,7 @@ static void dbtoa_free(t_dbtoa *x)
   t_freebytes(x->output_list,x->bytes);
 }
 
-void dbtoa_setup(void)
+CYCLONE_OBJ_API void dbtoa_setup(void)
 {
   dbtoa_class = class_new(gensym("dbtoa"), (t_newmethod)dbtoa_new,
 			  (t_method)dbtoa_free,sizeof(t_dbtoa),0,0);

--- a/cyclone_objects/binaries/control/decide.c
+++ b/cyclone_objects/binaries/control/decide.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _decide
 {
@@ -59,7 +60,7 @@ static void *decide_new(t_floatarg f)
     return (x);
 }
 
-void decide_setup(void){
+CYCLONE_OBJ_API void decide_setup(void){
     decide_class = class_new(gensym("decide"), (t_newmethod)decide_new, 0,
         sizeof(t_decide), 0, A_DEFFLOAT, 0);
     class_addbang(decide_class, decide_bang);

--- a/cyclone_objects/binaries/control/decode.c
+++ b/cyclone_objects/binaries/control/decode.c
@@ -6,6 +6,7 @@
    The most important changes are listed in "pd-lib-notes.txt" file.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define DECODE_C74MAXOUTS  512  // CHECKED (max goes up higher but freezes) */
 #define DECODE_DEFOUTS     1
@@ -100,7 +101,7 @@ static void *Decode_new(t_floatarg val){
     return (x);
 }
 
-void decode_setup(void)
+CYCLONE_OBJ_API void decode_setup(void)
 {
     Decode_class = class_new(gensym("decode"),
 			     (t_newmethod)Decode_new,

--- a/cyclone_objects/binaries/control/drunk.c
+++ b/cyclone_objects/binaries/control/drunk.c
@@ -7,6 +7,7 @@
    cyclone's guidelines. */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "control/rand.h"
 
 #define DRUNK_DEFMAXVALUE  128
@@ -124,7 +125,7 @@ static void *drunk_new(t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void drunk_setup(void)
+CYCLONE_OBJ_API void drunk_setup(void)
 {
     drunk_class = class_new(gensym("drunk"),
 			    (t_newmethod)drunk_new, 0,

--- a/cyclone_objects/binaries/control/flush.c
+++ b/cyclone_objects/binaries/control/flush.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define FLUSH_NPITCHES  128
 
@@ -66,7 +67,7 @@ static void *flush_new(void)
     return (x);
 }
 
-void flush_setup(void)
+CYCLONE_OBJ_API void flush_setup(void)
 {
     flush_class = class_new(gensym("flush"), 
 			    (t_newmethod)flush_new,

--- a/cyclone_objects/binaries/control/forward.c
+++ b/cyclone_objects/binaries/control/forward.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _forward
 {
@@ -55,7 +56,7 @@ static void *forward_new(t_symbol *s)
     return (x);
 }
 
-void forward_setup(void)
+CYCLONE_OBJ_API void forward_setup(void)
 {
     forward_class = class_new(gensym("forward"),
 			      (t_newmethod)forward_new, 0,

--- a/cyclone_objects/binaries/control/fromsymbol.c
+++ b/cyclone_objects/binaries/control/fromsymbol.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 int isnums(const char *s){
     //lifted from stack overflow, checks if every char is a digit (or period)
@@ -191,7 +192,7 @@ static void *fromsymbol_new(t_symbol * s, int argc, t_atom * argv){
 		return NULL;
 }
 
-void fromsymbol_setup(void)
+CYCLONE_OBJ_API void fromsymbol_setup(void)
 {
     fromsymbol_class = class_new(gensym("fromsymbol"),
 				 (t_newmethod)fromsymbol_new, 0,

--- a/cyclone_objects/binaries/control/funbuff.c
+++ b/cyclone_objects/binaries/control/funbuff.c
@@ -4,6 +4,7 @@
 
 #include <libgen.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "control/tree.h"
 #include "common/file.h"
 
@@ -755,7 +756,7 @@ static void *funbuff_new(t_symbol *s)
     return (x);
 }
 
-void funbuff_setup(void)
+CYCLONE_OBJ_API void funbuff_setup(void)
 {
     funbuff_class = class_new(gensym("funbuff"),
 			      (t_newmethod)funbuff_new,

--- a/cyclone_objects/binaries/control/funnel.c
+++ b/cyclone_objects/binaries/control/funnel.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define FUNNEL_MINSLOTS   2
 #define FUNNEL_INISIZE   32  /* LATER rethink */
@@ -303,7 +304,7 @@ static void *funnel_new(t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void funnel_setup(void)
+CYCLONE_OBJ_API void funnel_setup(void)
 {
     funnel_class = class_new(gensym("funnel"), (t_newmethod)funnel_new,
         (t_method)funnel_free, sizeof(t_funnel), 0, A_DEFFLOAT, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/control/gate.c
+++ b/cyclone_objects/binaries/control/gate.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define GATE_MINOUTS       1
 #define GATE_C74MAXOUTS  100
@@ -124,7 +125,7 @@ static void *gate_new(t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void gate_setup(void)
+CYCLONE_OBJ_API void gate_setup(void)
 {
     gate_class = class_new(gensym("gate"),
 			   (t_newmethod)gate_new,

--- a/cyclone_objects/binaries/control/grab.c
+++ b/cyclone_objects/binaries/control/grab.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "m_imp.h"
 #include "common/magicbit.h"
 
@@ -245,7 +246,7 @@ static void grab_free(t_grab *x)
 	freebytes(x->x_grabcons, x->x_noutlets * sizeof(*x->x_grabcons));
 }
 
-void grab_setup(void)
+CYCLONE_OBJ_API void grab_setup(void)
 {
     t_symbol *s = gensym("grab");
     grab_class = class_new(s, (t_newmethod)grab_new,

--- a/cyclone_objects/binaries/control/histo.c
+++ b/cyclone_objects/binaries/control/histo.c
@@ -8,6 +8,7 @@
 // porres 2016/2017, de-loud - no capital letter as default
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define HISTO_DEFSIZE  128
 
@@ -90,7 +91,7 @@ static void *Histo_new(t_floatarg f)
     return (x);
 }
 
-void histo_setup(void)
+CYCLONE_OBJ_API void histo_setup(void)
 {
     Histo_class = class_new(gensym("histo"),
 			    (t_newmethod)Histo_new,

--- a/cyclone_objects/binaries/control/iter.c
+++ b/cyclone_objects/binaries/control/iter.c
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define ITER_INISIZE  8  /* LATER rethink */
@@ -93,7 +94,7 @@ static void *iter_new(void)
     return (x);
 }
 
-void iter_setup(void)
+CYCLONE_OBJ_API void iter_setup(void)
 {
     iter_class = class_new(gensym("iter"),
 			   (t_newmethod)iter_new,

--- a/cyclone_objects/binaries/control/join.c
+++ b/cyclone_objects/binaries/control/join.c
@@ -2,6 +2,7 @@
 
 
 #include "m_pd.h"
+#include <common/api.h>
 #include<stdlib.h>
 #include<string.h>
 
@@ -250,7 +251,7 @@ static void join_inlet_triggers(t_join_inlet *x, t_symbol* s, int argc, t_atom* 
 	};
 
 }
-extern void join_setup(void)
+extern CYCLONE_OBJ_API void join_setup(void)
 {
     t_class* c = NULL;
     

--- a/cyclone_objects/binaries/control/linedrive.c
+++ b/cyclone_objects/binaries/control/linedrive.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 
 #define logf  log
@@ -97,7 +98,7 @@ static void *linedrive_new(t_floatarg maxin, t_floatarg maxout,
     return (x);
 }
 
-void linedrive_setup(void)
+CYCLONE_OBJ_API void linedrive_setup(void)
 {
     linedrive_class = class_new(gensym("linedrive"),
 				(t_newmethod)linedrive_new, 0,

--- a/cyclone_objects/binaries/control/listfunnel.c
+++ b/cyclone_objects/binaries/control/listfunnel.c
@@ -28,6 +28,7 @@
 // Derek Kwan 2017 - ported from maxlib, some restructuring, added offset, support for anythings, symbols
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -99,7 +100,7 @@ static void *listfunnel_new(t_floatarg f)
     return (void *)x;
 }
 
-void listfunnel_setup(void)
+CYCLONE_OBJ_API void listfunnel_setup(void)
 {
     listfunnel_class = class_new(gensym("listfunnel"), (t_newmethod)listfunnel_new,
     	0, sizeof(t_listfunnel), 0, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/control/loadmess.c
+++ b/cyclone_objects/binaries/control/loadmess.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "g_canvas.h"
 
 #define IS_A_POINTER(atom,index) ((atom+index)->a_type == A_POINTER)
@@ -231,7 +232,7 @@ static void *loadmess_new(t_symbol *s, int ac, t_atom *av)
   return (x);
 }
 
-void loadmess_setup(void)
+CYCLONE_OBJ_API void loadmess_setup(void)
 {
   loadmess_class = class_new(gensym("loadmess"), (t_newmethod)loadmess_new,
 			     (t_method)loadmess_free, sizeof(t_loadmess), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/control/match.c
+++ b/cyclone_objects/binaries/control/match.c
@@ -6,6 +6,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define MATCH_INISIZE  8  /* LATER rethink */
@@ -199,7 +200,7 @@ static void *match_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void match_setup(void)
+CYCLONE_OBJ_API void match_setup(void)
 {
     match_class = class_new(gensym("match"),
 			    (t_newmethod)match_new,

--- a/cyclone_objects/binaries/control/maximum.c
+++ b/cyclone_objects/binaries/control/maximum.c
@@ -17,6 +17,7 @@ here,  just set to 1
 */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define PDCYMAXN 256 //max numbers allowable in list
 
@@ -111,7 +112,7 @@ static void *maximum_new(t_floatarg f)
     return (x);
 }
 
-void maximum_setup(void)
+CYCLONE_OBJ_API void maximum_setup(void)
 {
     maximum_class = class_new(gensym("maximum"),
 			      (t_newmethod)maximum_new, (t_method)maximum_free,

--- a/cyclone_objects/binaries/control/mean.c
+++ b/cyclone_objects/binaries/control/mean.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _mean
 {
@@ -66,7 +67,7 @@ static void *mean_new(void)
     return (x);
 }
 
-void mean_setup(void)
+CYCLONE_OBJ_API void mean_setup(void)
 {
     mean_class = class_new(gensym("mean"),
 			   (t_newmethod)mean_new, 0,

--- a/cyclone_objects/binaries/control/midiflush.c
+++ b/cyclone_objects/binaries/control/midiflush.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define MIDIFLUSH_NCHANNELS    16
 #define MIDIFLUSH_NPITCHES    128
@@ -89,7 +90,7 @@ static void *midiflush_new(void)
     return (x);
 }
 
-void midiflush_setup(void)
+CYCLONE_OBJ_API void midiflush_setup(void)
 {
     midiflush_class = class_new(gensym("midiflush"), 
 				(t_newmethod)midiflush_new,

--- a/cyclone_objects/binaries/control/midiformat.c
+++ b/cyclone_objects/binaries/control/midiformat.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <string.h>
 
 //adding attributes, x_hires and associated modes - Derek Kwan 2016
@@ -177,7 +178,7 @@ static void *midiformat_new(t_symbol * s, int argc, t_atom * argv)
         return NULL;
 }
 
-void midiformat_setup(void)
+CYCLONE_OBJ_API void midiformat_setup(void)
 {
     midiformat_class = class_new(gensym("midiformat"), 
 				 (t_newmethod)midiformat_new, 0,

--- a/cyclone_objects/binaries/control/midiparse.c
+++ b/cyclone_objects/binaries/control/midiparse.c
@@ -5,6 +5,7 @@
 //adding x_hires and associated bendout options - Derek Kwan 2016
 //
 #include "m_pd.h"
+#include <common/api.h>
 #include <string.h>
 
 typedef struct _midiparse
@@ -181,7 +182,7 @@ static void *midiparse_new(t_symbol * s, int argc, t_atom * argv)
         return NULL;
 }
 
-void midiparse_setup(void)
+CYCLONE_OBJ_API void midiparse_setup(void)
 {
     midiparse_class = class_new(gensym("midiparse"), 
 				(t_newmethod)midiparse_new, 0,

--- a/cyclone_objects/binaries/control/minimum.c
+++ b/cyclone_objects/binaries/control/minimum.c
@@ -17,6 +17,7 @@ here,  just set to 1
 */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define PDCYMINN 256 //max numbers allowable in list
 
@@ -111,7 +112,7 @@ static void *minimum_new(t_floatarg f)
     return (x);
 }
 
-void minimum_setup(void)
+CYCLONE_OBJ_API void minimum_setup(void)
 {
     minimum_class = class_new(gensym("minimum"),
 			      (t_newmethod)minimum_new, (t_method)minimum_free,

--- a/cyclone_objects/binaries/control/mousefilter.c
+++ b/cyclone_objects/binaries/control/mousefilter.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "control/gui.h"
 
 //2016 note: now works with anything, pre v3: only floats - Derek Kwan
@@ -243,7 +244,7 @@ static void mousefilter_proxy_setup(void){
 }
 
 
-void mousefilter_setup(void)
+CYCLONE_OBJ_API void mousefilter_setup(void)
 {
     mousefilter_class = class_new(gensym("mousefilter"),
 				  (t_newmethod)mousefilter_new,

--- a/cyclone_objects/binaries/control/mousestate.c
+++ b/cyclone_objects/binaries/control/mousestate.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "control/gui.h"
 #include "g_canvas.h"
 
@@ -293,7 +294,7 @@ static void *mousestate_new(void)
     return (x);
 }
 
-void mousestate_setup(void)
+CYCLONE_OBJ_API void mousestate_setup(void)
 {
     mousestate_class = class_new(gensym("mousestate"),
 				 (t_newmethod)mousestate_new,

--- a/cyclone_objects/binaries/control/mtr.c
+++ b/cyclone_objects/binaries/control/mtr.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/shared.h"
 #include "common/file.h"
 
@@ -781,7 +782,7 @@ static void *mtr_new(t_floatarg f)
     return (x);
 }
 
-void mtr_setup(void)
+CYCLONE_OBJ_API void mtr_setup(void)
 {
     mtrack_class = class_new(gensym("_mtrack"), 0, 0,
 			     sizeof(t_mtrack), CLASS_PD | CLASS_NOINLET, 0);

--- a/cyclone_objects/binaries/control/next.c
+++ b/cyclone_objects/binaries/control/next.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 //#define NEXT_USEEVENTNO
 
@@ -49,7 +50,7 @@ static void *next_new(void)
     return (x);
 }
 
-void next_setup(void)
+CYCLONE_OBJ_API void next_setup(void)
 {
     next_class = class_new(gensym("next"),
 			   (t_newmethod)next_new, 0,

--- a/cyclone_objects/binaries/control/offer.c
+++ b/cyclone_objects/binaries/control/offer.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "control/tree.h"
 
 //adding offer_bang, typecasting arg in offer_ft1 to and from int to get rid of mantissa  - Derek Kwan 2016
@@ -97,7 +98,7 @@ static void offer_bang(t_offer * x){
 
 }
 
-void offer_setup(void)
+CYCLONE_OBJ_API void offer_setup(void)
 {
     offer_class = class_new(gensym("offer"),
 			    (t_newmethod)offer_new,

--- a/cyclone_objects/binaries/control/onebang.c
+++ b/cyclone_objects/binaries/control/onebang.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 //made the right inlet a proxy inlet with corresponding proxy class to take care of anythings - DK 2016
 
@@ -108,7 +109,7 @@ static void *onebang_new(t_floatarg f)
     return (x);
 }
 
-void onebang_setup(void)
+CYCLONE_OBJ_API void onebang_setup(void)
 {
     onebang_class = class_new(gensym("onebang"),
 			      (t_newmethod)onebang_new, 0,

--- a/cyclone_objects/binaries/control/pak.c
+++ b/cyclone_objects/binaries/control/pak.c
@@ -4,6 +4,7 @@
 */
 
 #include <m_pd.h>
+#include <common/api.h>
 
 static t_class *pak_class;
 static t_class* pak_inlet_class;
@@ -233,7 +234,7 @@ static void pak_inlet_set(t_pak_inlet *x, t_symbol* s, int argc, t_atom* argv)
     pak_copy(x->x_owner, x->x_max, x->x_atoms, argc, argv, x->x_idx);
 }
 
-extern void pak_setup(void)
+CYCLONE_OBJ_API extern void pak_setup(void)
 {
     t_class* c = NULL;
     

--- a/cyclone_objects/binaries/control/past.c
+++ b/cyclone_objects/binaries/control/past.c
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #define PAST_STACK 128 // check
 #define PAST_MAX 512 // check
@@ -193,7 +194,7 @@ static void *past_free(t_past *x)
     return (void *)x;
 }
 
-void past_setup(void)
+CYCLONE_OBJ_API void past_setup(void)
 {
     past_class = class_new(gensym("past"),
 			   (t_newmethod)past_new,

--- a/cyclone_objects/binaries/control/peak.c
+++ b/cyclone_objects/binaries/control/peak.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _peak{
     t_object   x_ob;
@@ -45,7 +46,7 @@ static void *peak_new(t_symbol *s, int argc, t_atom *argv){
     return (x);
 }
 
-void peak_setup(void){
+CYCLONE_OBJ_API void peak_setup(void){
     peak_class = class_new(gensym("peak"), (t_newmethod)peak_new, 0,
 			   sizeof(t_peak), 0, A_GIMME, 0);
     class_addcreator((t_newmethod)peak_new, gensym("Peak"), A_GIMME, 0);

--- a/cyclone_objects/binaries/control/poltocar.c
+++ b/cyclone_objects/binaries/control/poltocar.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #if defined(_WIN32) || defined(__APPLE__)
 /* cf pd/src/x_arithmetic.c */
@@ -38,7 +39,7 @@ static void *poltocar_new(void){
     return (x);
 }
 
-void poltocar_setup(void){
+CYCLONE_OBJ_API void poltocar_setup(void){
     poltocar_class = class_new(gensym("poltocar"), (t_newmethod)poltocar_new, 0,
 			       sizeof(t_poltocar), 0, 0);
     class_addfloat(poltocar_class, poltocar_float);

--- a/cyclone_objects/binaries/control/pong.c
+++ b/cyclone_objects/binaries/control/pong.c
@@ -1,6 +1,7 @@
 //2016 by Derek Kwan
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 #include <string.h>
 #include <ctype.h>
@@ -278,7 +279,7 @@ static void pong_setmode(t_pong *x, t_symbol *s)
 				x->mode = setmode;
     }
 
-	void pong_setup(void){
+	CYCLONE_OBJ_API void pong_setup(void){
 	pong_class = class_new(gensym("pong"), (t_newmethod)pong_new, 0,
 			sizeof(t_pong), 0, A_GIMME, 0);
 	class_addfloat(pong_class, pong_float);

--- a/cyclone_objects/binaries/control/prepend.c
+++ b/cyclone_objects/binaries/control/prepend.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define PREPEND_INISIZE   32  /* LATER rethink */
@@ -263,7 +264,7 @@ static void *prepend_new(t_symbol *s, int ac, t_atom *av){
     return (x);
 }
 
-void prepend_setup(void){
+CYCLONE_OBJ_API void prepend_setup(void){
     prepend_class = class_new(gensym("prepend"), (t_newmethod)prepend_new,
         (t_method)prepend_free, sizeof(t_prepend), 0, A_GIMME, 0);
     class_addbang(prepend_class, prepend_bang);

--- a/cyclone_objects/binaries/control/prob.c
+++ b/cyclone_objects/binaries/control/prob.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/file.h"
 #include "control/rand.h"
 
@@ -265,7 +266,7 @@ static void *prob_new(void){
     return (x);
 }
 
-void prob_setup(void){
+CYCLONE_OBJ_API void prob_setup(void){
     prob_class = class_new(gensym("prob"), (t_newmethod)prob_new,
         (t_method)prob_free, sizeof(t_prob), 0, 0);
     class_addbang(prob_class, prob_bang);

--- a/cyclone_objects/binaries/control/pv.c
+++ b/cyclone_objects/binaries/control/pv.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "g_canvas.h"
 #include "common/grow.h"
 
@@ -441,7 +442,7 @@ static void *pv_new(t_symbol *s, int ac, t_atom *av){
     return(x);
 }
 
-void pv_setup(void)
+CYCLONE_OBJ_API void pv_setup(void)
 {
     pv_class = class_new(gensym("pv"),
 			 (t_newmethod)pv_new,

--- a/cyclone_objects/binaries/control/rdiv.c
+++ b/cyclone_objects/binaries/control/rdiv.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Porres.
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _rdiv
 {
@@ -32,7 +33,7 @@ static void *rdiv_new(t_floatarg f)
     return (x);
 }
 
-void rdiv_setup(void)
+CYCLONE_OBJ_API void rdiv_setup(void)
 {
     rdiv_class = class_new(gensym("rdiv"), (t_newmethod)rdiv_new, 0,
                 sizeof(t_rdiv), 0, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/control/rminus.c
+++ b/cyclone_objects/binaries/control/rminus.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Porres.
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _rminus
 {
@@ -31,7 +32,7 @@ static void *rminus_new(t_floatarg f)
     return (x);
 }
 
-void rminus_setup(void)
+CYCLONE_OBJ_API void rminus_setup(void)
 {
     rminus_class = class_new(gensym("rminus"), (t_newmethod)rminus_new,
             0, sizeof(t_rminus), 0, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/control/round.c
+++ b/cyclone_objects/binaries/control/round.c
@@ -1,6 +1,7 @@
 //2016 by Derek Kwan
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 #include <string.h>
 #include <ctype.h>
@@ -179,7 +180,7 @@ static void round_nearest(t_round *x, t_float f, t_float glob){
 	};
 }
 
-void round_setup(void)
+CYCLONE_OBJ_API void round_setup(void)
 {
 	round_class = class_new(gensym("round"), (t_newmethod)round_new, 0,
 	sizeof(t_round), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/control/scale.c
+++ b/cyclone_objects/binaries/control/scale.c
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <math.h>
 
 
@@ -145,7 +146,7 @@ static void *scale_new(t_symbol *s, int argc, t_atom *argv)
   return (x);
 }
 
-void scale_setup(void)
+CYCLONE_OBJ_API void scale_setup(void)
 {
   t_class *c;
   scale_class = class_new(gensym("scale"), (t_newmethod)scale_new,

--- a/cyclone_objects/binaries/control/seq.c
+++ b/cyclone_objects/binaries/control/seq.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 #include "common/file.h"
 #include "control/mifi.h"
@@ -1139,7 +1140,7 @@ static void *seq_new(t_symbol *s)
     return (x);
 }
 
-void seq_setup(void)
+CYCLONE_OBJ_API void seq_setup(void)
 {
     seq_class = class_new(gensym("seq"), (t_newmethod)seq_new,
         (t_method)seq_free, sizeof(t_seq), 0, A_DEFSYM, 0);

--- a/cyclone_objects/binaries/control/sinh.c
+++ b/cyclone_objects/binaries/control/sinh.c
@@ -7,6 +7,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _sinh
 {
@@ -34,7 +35,7 @@ static void *sinh_new(t_floatarg f)
     return (x);
 }
 
-void sinh_setup(void)
+CYCLONE_OBJ_API void sinh_setup(void)
 {
     sinh_class = class_new(gensym("sinh"), (t_newmethod)sinh_new, 0,
 			   sizeof(t_sinh), 0, A_DEFFLOAT, 0);

--- a/cyclone_objects/binaries/control/speedlim.c
+++ b/cyclone_objects/binaries/control/speedlim.c
@@ -6,6 +6,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define SPEEDLIM_INISIZE   32  /* LATER rethink */
@@ -156,7 +157,7 @@ static void *speedlim_new(t_floatarg f)
     return (x);
 }
 
-void speedlim_setup(void)
+CYCLONE_OBJ_API void speedlim_setup(void)
 {
     speedlim_class = class_new(gensym("speedlim"),
 			       (t_newmethod)speedlim_new,

--- a/cyclone_objects/binaries/control/spell.c
+++ b/cyclone_objects/binaries/control/spell.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _spell{
     t_object  x_ob;
@@ -124,7 +125,7 @@ static void *spell_new(t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void spell_setup(void)
+CYCLONE_OBJ_API void spell_setup(void)
 {
     spell_class = class_new(gensym("spell"),
 			    (t_newmethod)spell_new, 0,

--- a/cyclone_objects/binaries/control/split.c
+++ b/cyclone_objects/binaries/control/split.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 /* CHECKED:
    'list <symbol>' silently ignored (LATER remove a warning)
@@ -55,7 +56,7 @@ static void *split_new(t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void split_setup(void)
+CYCLONE_OBJ_API void split_setup(void)
 {
     split_class = class_new(gensym("split"),
 			    (t_newmethod)split_new, 0,

--- a/cyclone_objects/binaries/control/spray.c
+++ b/cyclone_objects/binaries/control/spray.c
@@ -5,6 +5,7 @@
 //de-loudized - Derek Kwan 2016
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define SPRAY_MINOUTS  1
 /* CHECKED: no upper limit */
@@ -101,7 +102,7 @@ static void *spray_new(t_floatarg f1, t_floatarg f2, t_floatarg f3)
     return (x);
 }
 
-void spray_setup(void)
+CYCLONE_OBJ_API void spray_setup(void)
 {
     spray_class = class_new(gensym("spray"),
 			    (t_newmethod)spray_new,

--- a/cyclone_objects/binaries/control/sprintf.c
+++ b/cyclone_objects/binaries/control/sprintf.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 /* Pattern types.  These are the parsing routine's return values.
    If returned value is >= SPRINTF_MINSLOTTYPE, then another slot
@@ -615,7 +616,7 @@ static void *sprintf_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void sprintf_setup(void)
+CYCLONE_OBJ_API void sprintf_setup(void)
 {
     sprintf_class = class_new(gensym("sprintf"),
 			      (t_newmethod)sprintf_new,

--- a/cyclone_objects/binaries/control/substitute.c
+++ b/cyclone_objects/binaries/control/substitute.c
@@ -15,6 +15,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define SUBSTITUTE_INISIZE   32  /* LATER rethink */
@@ -366,7 +367,7 @@ static void *substitute_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void substitute_setup(void)
+CYCLONE_OBJ_API void substitute_setup(void)
 {
     substitute_class = class_new(gensym("substitute"),
 			      (t_newmethod)substitute_new,

--- a/cyclone_objects/binaries/control/sustain.c
+++ b/cyclone_objects/binaries/control/sustain.c
@@ -1,6 +1,7 @@
 //redone 2016 by Derek Kwan (with some inspiration from the old code by krzYszcz (2002-2003)
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -267,7 +268,7 @@ static void *sustain_new(t_symbol *s, int argc, t_atom *argv)
 	
 }
 
-void sustain_setup(void)
+CYCLONE_OBJ_API void sustain_setup(void)
 {
 	sustain_class = class_new(gensym("sustain"), (t_newmethod)sustain_new, (t_method)sustain_free,
 	sizeof(t_sustain), 0, A_GIMME, 0);

--- a/cyclone_objects/binaries/control/switch.c
+++ b/cyclone_objects/binaries/control/switch.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 #define SWITCH_MININLETS       2  /* LATER consider using 1 (with a warning) */
 #define SWITCH_C74MAXINLETS  100
@@ -130,7 +131,7 @@ static void *switch_new(t_floatarg f1, t_floatarg f2)
     return (x);
 }
 
-void switch_setup(void)
+CYCLONE_OBJ_API void switch_setup(void)
 {
     switch_class = class_new(gensym("switch"),
 			     (t_newmethod)switch_new,

--- a/cyclone_objects/binaries/control/table.c
+++ b/cyclone_objects/binaries/control/table.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "g_canvas.h"
 #include "common/grow.h"
 #include "common/file.h"
@@ -806,7 +807,7 @@ static void *table_new(t_symbol *s, int argc, t_atom *argv){
         return NULL;
 }
 
-void table_setup(void){
+CYCLONE_OBJ_API void table_setup(void){
     table_class = class_new(gensym("Table"),
         (t_newmethod)table_new, (t_method)table_free, sizeof(t_table), 0, A_GIMME, 0);
     class_addcreator((t_newmethod)table_new, gensym("cyclone/table"), A_GIMME, 0);

--- a/cyclone_objects/binaries/control/tanh.c
+++ b/cyclone_objects/binaries/control/tanh.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 #if defined(_WIN32) || defined(__APPLE__)
 /* cf pd/src/x_arithmetic.c */
@@ -38,7 +39,7 @@ static void *tanh_new(t_floatarg f)
     return (x);
 }
 
-void tanh_setup(void)
+CYCLONE_OBJ_API void tanh_setup(void)
 {
     tanh_class = class_new(gensym("tanh"),
 			   (t_newmethod)tanh_new, 0,

--- a/cyclone_objects/binaries/control/thresh.c
+++ b/cyclone_objects/binaries/control/thresh.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define THRESH_INISIZE    32  /* LATER rethink */
@@ -163,7 +164,7 @@ static void *thresh_new(t_floatarg f)
     return (x);
 }
 
-void thresh_setup(void)
+CYCLONE_OBJ_API void thresh_setup(void)
 {
     thresh_class = class_new(gensym("thresh"),
 			     (t_newmethod)thresh_new,

--- a/cyclone_objects/binaries/control/togedge.c
+++ b/cyclone_objects/binaries/control/togedge.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _togedge{
     t_object   x_ob;
@@ -47,7 +48,7 @@ static void *togedge_new(void){
     return (x);
 }
 
-void togedge_setup(void){
+CYCLONE_OBJ_API void togedge_setup(void){
     togedge_class = class_new(gensym("togedge"),
         (t_newmethod)togedge_new, 0, sizeof(t_togedge), 0, 0);
     class_addcreator((t_newmethod)togedge_new, gensym("TogEdge"), 0, 0);

--- a/cyclone_objects/binaries/control/tosymbol.c
+++ b/cyclone_objects/binaries/control/tosymbol.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 
 #define TOSYMBOL_INISTRING   128  /* LATER rethink */
@@ -215,7 +216,7 @@ static void *tosymbol_new(t_symbol *s, int argc, t_atom *argv)
 		return NULL;
 }
 
-void tosymbol_setup(void)
+CYCLONE_OBJ_API void tosymbol_setup(void)
 {
     tosymbol_class = class_new(gensym("tosymbol"),
 			       (t_newmethod)tosymbol_new,

--- a/cyclone_objects/binaries/control/trough.c
+++ b/cyclone_objects/binaries/control/trough.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _trough{
     t_object   x_ob;
@@ -45,7 +46,7 @@ static void *trough_new(t_symbol *s, int argc, t_atom *argv){
     return (x);
 }
 
-void trough_setup(void){
+CYCLONE_OBJ_API void trough_setup(void){
     trough_class = class_new(gensym("trough"), (t_newmethod)trough_new, 0,
 			     sizeof(t_trough), 0, A_GIMME, 0);
     class_addcreator((t_newmethod)trough_new, gensym("Trough"), A_GIMME, 0);

--- a/cyclone_objects/binaries/control/universal.c
+++ b/cyclone_objects/binaries/control/universal.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "g_canvas.h"
 #include "m_imp.h"
 
@@ -154,7 +155,7 @@ static void *universal_new(t_floatarg f)
     return (x);
 }
 
-void universal_setup(void)
+CYCLONE_OBJ_API void universal_setup(void)
 {
     universal_class = class_new(gensym("universal"),
 			      (t_newmethod)universal_new, 0,

--- a/cyclone_objects/binaries/control/unjoin.c
+++ b/cyclone_objects/binaries/control/unjoin.c
@@ -1,6 +1,7 @@
 //Derek Kwan 2017 - brand new object!
 
 #include "m_pd.h"
+#include <common/api.h>
 #include <string.h>
 
 #define UNJOIN_MINOUTLETS  2 //not including extra outlet
@@ -154,7 +155,7 @@ static void *unjoin_new(t_symbol *s, int argc, t_atom * argv)
     return (x);
 }
 
-void unjoin_setup(void)
+CYCLONE_OBJ_API void unjoin_setup(void)
 {
     unjoin_class = class_new(gensym("unjoin"),
 			    (t_newmethod)unjoin_new,

--- a/cyclone_objects/binaries/control/urn.c
+++ b/cyclone_objects/binaries/control/urn.c
@@ -8,6 +8,7 @@
    array), and should be put somewhere in the docs... */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "common/grow.h"
 #include "control/rand.h"
 
@@ -103,7 +104,7 @@ static void *urn_new(t_floatarg f1, t_floatarg f2){
     return (x);
 }
 
-void urn_setup(void){
+CYCLONE_OBJ_API void urn_setup(void){
     urn_class = class_new(gensym("urn"), (t_newmethod)urn_new, (t_method)urn_free,
         sizeof(t_urn), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
     class_addbang(urn_class, urn_bang);

--- a/cyclone_objects/binaries/control/uzi.c
+++ b/cyclone_objects/binaries/control/uzi.c
@@ -5,6 +5,7 @@
 /* CHECKME negative 'nbangs' value set during run-time */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _uzi
 {
@@ -116,7 +117,7 @@ static void *uzi_new(t_symbol *s, int ac, t_atom *av)
     return (x);
 }
 
-void uzi_setup(void)
+CYCLONE_OBJ_API void uzi_setup(void)
 {
     uzi_class = class_new(gensym("uzi"),
 			  (t_newmethod)uzi_new, 0,

--- a/cyclone_objects/binaries/control/xbendin.c
+++ b/cyclone_objects/binaries/control/xbendin.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _xbendin
 {
@@ -82,7 +83,7 @@ static void *xbendin_new(t_floatarg f)
     return (x);
 }
 
-void xbendin_setup(void)
+CYCLONE_OBJ_API void xbendin_setup(void)
 {
     xbendin_class = class_new(gensym("xbendin"), 
 			      (t_newmethod)xbendin_new, 0,

--- a/cyclone_objects/binaries/control/xbendin2.c
+++ b/cyclone_objects/binaries/control/xbendin2.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 /* LATER find a better way to synchronize with xbendin,
    while avoiding the c74's bug... */
@@ -88,7 +89,7 @@ static void *xbendin2_new(t_floatarg f)
     return (x);
 }
 
-void xbendin2_setup(void)
+CYCLONE_OBJ_API void xbendin2_setup(void)
 {
     xbendin2_class = class_new(gensym("xbendin2"), 
 			       (t_newmethod)xbendin2_new, 0,

--- a/cyclone_objects/binaries/control/xbendout.c
+++ b/cyclone_objects/binaries/control/xbendout.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _xbendout
 {
@@ -43,7 +44,7 @@ static void *xbendout_new(t_floatarg f)
     return (x);
 }
 
-void xbendout_setup(void)
+CYCLONE_OBJ_API void xbendout_setup(void)
 {
     xbendout_class = class_new(gensym("xbendout"), 
 			       (t_newmethod)xbendout_new, 0,

--- a/cyclone_objects/binaries/control/xbendout2.c
+++ b/cyclone_objects/binaries/control/xbendout2.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _xbendout2
 {
@@ -49,7 +50,7 @@ static void *xbendout2_new(t_floatarg f)
     return (x);
 }
 
-void xbendout2_setup(void)
+CYCLONE_OBJ_API void xbendout2_setup(void)
 {
     xbendout2_class = class_new(gensym("xbendout2"), 
 				(t_newmethod)xbendout2_new, 0,

--- a/cyclone_objects/binaries/control/xnotein.c
+++ b/cyclone_objects/binaries/control/xnotein.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _xnotein
 {
@@ -89,7 +90,7 @@ static void *xnotein_new(t_floatarg f)
     return (x);
 }
 
-void xnotein_setup(void)
+CYCLONE_OBJ_API void xnotein_setup(void)
 {
     xnotein_class = class_new(gensym("xnotein"), 
 			      (t_newmethod)xnotein_new, 0,

--- a/cyclone_objects/binaries/control/xnoteout.c
+++ b/cyclone_objects/binaries/control/xnoteout.c
@@ -3,6 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
+#include <common/api.h>
 
 typedef struct _xnoteout
 {
@@ -51,7 +52,7 @@ static void *xnoteout_new(t_floatarg f)
     return (x);
 }
 
-void xnoteout_setup(void)
+CYCLONE_OBJ_API void xnoteout_setup(void)
 {
     xnoteout_class = class_new(gensym("xnoteout"), 
 			       (t_newmethod)xnoteout_new, 0,

--- a/cyclone_objects/binaries/control/zl.c
+++ b/cyclone_objects/binaries/control/zl.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "m_pd.h"
+#include <common/api.h>
 
 // LATER test reentrancy, tune speedwise
 
@@ -1616,7 +1617,7 @@ static void zl_setupmode(char *id, int flags,
     zl_doitfn[i] = dfn;
 }
 
-void zl_setup(void){
+CYCLONE_OBJ_API void zl_setup(void){
     zl_class = class_new(gensym("zl"), (t_newmethod)zl_new,
             (t_method)zl_free, sizeof(t_zl), 0, A_GIMME, 0);
     class_addbang(zl_class, zl_bang);

--- a/cyclone_objects/binaries/cyclone_lib.c
+++ b/cyclone_objects/binaries/cyclone_lib.c
@@ -19,6 +19,7 @@
  single binaries in the cyclone package  */
 
 #include "m_pd.h"
+#include <common/api.h>
 #include "m_imp.h"
 #include "common/shared.h"
 #include "common//magicbit.h"
@@ -654,7 +655,7 @@ static void *cyclone_new(void){
 
 /* ----------------------------- SETUP ------------------------------ */
 
-void cyclone_setup(void)
+CYCLONE_API void cyclone_setup(void)
 {
     cyclone_class = class_new(gensym("cyclone"), cyclone_new, 0, sizeof(t_cyclone), 0, 0);
     class_addmethod(cyclone_class, (t_method)cyclone_about, gensym("about"), 0);

--- a/shared/common/api.h
+++ b/shared/common/api.h
@@ -33,4 +33,4 @@
 #endif
 
 
-#endif __CYCLONE_API_H__
+#endif // __CYCLONE_API_H__

--- a/shared/common/api.h
+++ b/shared/common/api.h
@@ -1,0 +1,36 @@
+/* Copyright (c) 2018 Diego Barrios Romero.
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+
+/* API symbol definitions.
+ * Symbols that are part of the library interface need to be exported
+ * so that these can be found by the loaders.
+ * i.e. *_setup functions need to be exported so that pure-data finds them
+ * at load time.
+ */
+
+#ifndef __CYCLONE_API_H__
+#define __CYCLONE_API_H__
+
+// For use in the cyclone main library
+#if defined(_MSC_VER)
+// Export the symbol to the DLL interface
+#  define CYCLONE_API __declspec(dllexport)
+#else
+// On UNIX set this to visibility default if you change the default symbol
+// visibility to hidden.
+#  define CYCLONE_API
+#endif
+
+// For use on cyclone objects
+#if defined(_MSC_VER) && !defined(CYCLONE_SINGLE_LIBRARY)
+// Export the symbol to the DLL interface
+#  define CYCLONE_OBJ_API __declspec(dllexport)
+#else
+// On UNIX set this to visibility default if you change the default symbol
+// visibility to hidden and you are not building a single library.
+#  define CYCLONE_OBJ_API
+#endif
+
+
+#endif __CYCLONE_API_H__


### PR DESCRIPTION
This exports the `*_setup` symbols when compiling with MSVC so that pure-data can find them when loading the objects.
On UNIX platforms this is not necessary at the moment because the default symbol visibility is set to `default` at compile time.

This includes the `CYCLONE_SINGLE_LIBRARY` definition in preparation for another PR I will submit soon where I add an option to create a single library including all cyclone objects as including so many libraries is not very practical for us.