### PR TITLE
Windows compilation (update fix for #460)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,14 +295,14 @@ README.pdf \
 # It can be found in the MinGW directory (usually "C:\msys64\mingw64\bin" for 64bit builds 
 # or "C:\msys64\mingw32\bin" for 32bit builds) directory and should be
 # copied to the current directory before installation or packaging.
-# We use $(MINGW_CHOST) for compiler Arch detection. (not tested for cross-compiling).
+# We use $(MSYSTEM) for compiler Arch detection. (not tested for cross-compiling).
 #
 # "pthreadGC-3.dll" and "libgcc_s_dw2-1.dll" need to be copied if compiling with Msys1.
 # They are copied just in case.
 #
 
 ifeq (MINGW,$(findstring MINGW,$(uname)))
-  ifeq ($(MINGW_CHOST), i686-w64-mingw32)
+  ifeq ($(MSYSTEM), MINGW32)
     datafiles += maintenance/windows_dll/msys2-32/libwinpthread-1.dll
     datafiles += maintenance/windows_dll/pthreadGC-3.dll
     datafiles += maintenance/windows_dll/libgcc_s_dw2-1.dll


### PR DESCRIPTION
Change variable to `$(MSYSTEM)` to make it better for Msys2 and compatible with Msys1.

