### PR TITLE
first attempt at pd-nilwind alias code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ ldlibs += -lpthread
 exe.extension = .exe
 endif
 
+forLinux   = aliases=true
+
 #######################################################################
                     ## START OF CYCLONE CLASSES ##
 #######################################################################
@@ -314,3 +316,45 @@ endif
 ### pd-lib-builder ######################################################
 
 include pd-lib-builder/Makefile.pdlibbuilder
+
+### borrowing aliases code from pd-nilwind
+
+install: install-aliases
+
+install-aliases: all
+ifeq ($(aliases), true)
+	$(INSTALL_DIR) -v $(installpath)
+	cd $(installpath); \
+        ln -s -f append.$(extension) Append.$(extension); \
+        ln -s -f append-help.pd Append-help.pd; \
+        ln -s -f borax.$(extension) Borax.$(extension); \
+        ln -s -f borax-help.pd Borax-help.pd; \
+        ln -s -f bucket.$(extension) Bucket.$(extension); \
+        ln -s -f bucket-help.pd Bucket-help.pd; \
+        ln -s -f clip.$(extension) Clip.$(extension); \
+        ln -s -f clip-help.pd Clip-help.pd; \
+        ln -s -f decode.$(extension) Decode.$(extension); \
+        ln -s -f decode-help.pd Decode-help.pd; \
+        ln -s -f histo.$(extension) Histo.$(extension); \
+        ln -s -f histo-help.pd Histo-help.pd; \
+        ln -s -f mousestate.$(extension) MouseState.$(extension); \
+        ln -s -f mousestate-help.pd MouseState-help.pd; \
+        ln -s -f peak.$(extension) Peak.$(extension); \
+        ln -s -f peak-help.pd Peak-help.pd; \
+        ln -s -f table.$(extension) Table.$(extension); \
+        ln -s -f table-help.pd Table-help.pd; \
+        ln -s -f togedge.$(extension) TogEdge.$(extension); \
+        ln -s -f togedge-help.pd TogEdge-help.pd; \
+        ln -s -f trough.$(extension) Trough.$(extension); \
+        ln -s -f trough-help.pd Trough-help.pd; \
+        ln -s -f uzi.$(extension) Uzi.$(extension); \
+        ln -s -f uzi-help.pd Uzi-help.pd; \
+        ln -s -f clip~.$(extension) Clip~.$(extension); \
+        ln -s -f clip~-help.pd Clip~-help.pd; \
+        ln -s -f line~.$(extension) Line~.$(extension); \
+        ln -s -f line~-help.pd Line~-help.pd; \
+        ln -s -f scope~.$(extension) Scope~.$(extension); \
+        ln -s -f scope~-help.pd Scope~-help.pd; \
+        ln -s -f snapshot~.$(extension) Snapshot~.$(extension); \
+        ln -s -f snapshot~-help.pd Snapshot~-help.pd
+endif


### PR DESCRIPTION
( note: errors with `sudo make install`, namely 
`install: cannot stat '/lib/libwinpthread-1.dll': No such file or directory
pd-lib-builder/Makefile.pdlibbuilder:1112: recipe for target 'install-datafiles' failed
`
)

Anyways, basically copying the pertinent bits of the nilwind Makefile, (the end of it, and the `forLinux` bit at the top and removing mentions of cyclist), seems like you have to do `sudo make install-aliases` and it works (didn't find anything for building within directory)