### PR TITLE
Remove mingw dll copy when not building with MINGW.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ ifeq (MINGW,$(findstring MINGW,$(uname)))
     datafiles += ${MINGW_PREFIX}/bin/libwinpthread-1.dll
 
   else
-    datafiles += ${MINGW_PREFIX}/lib/libwinpthread-1.dll
+    ## datafiles += ${MINGW_PREFIX}/lib/libwinpthread-1.dll
 endif
 
 


### PR DESCRIPTION
Remove mingw dll copy as it breaks non Windows builds. May be it will be revisited later when there's a need to be able cross-compile for Windows from Linux