### PR TITLE
first attempt at coll resize

### DIFF
--- a/cyclone_objects/binaries/control/coll.c
+++ b/cyclone_objects/binaries/control/coll.c
@@ -869,8 +869,9 @@ static void coll_embedhook(t_pd *z, t_binbuf *bb, t_symbol *bindsym){
             binbuf_add(bb, cnt, at);
             binbuf_add(bb, ep->e_size, ep->e_data);
             binbuf_addsemi(bb);
-        }
-    }
+        };
+    };
+    if(x->x_ob.te_width != 0) binbuf_addv(bb, "ssf;", &s__X, gensym("f"), (float)x->x_ob.te_width);
 }
 
 static void collcommon_editorhook(t_pd *z, t_symbol *s, int ac, t_atom *av){
@@ -2053,3 +2054,4 @@ CYCLONE_OBJ_API void coll_setup(void){
        have it around, just in case... */
     hammerfile_setup(collcommon_class, 0);
 }
+


### PR DESCRIPTION
seems to add `#X f (te_width)` in the wrong spot compared to array and other things? like there's a `#C restore` thing that's still coll things, but still seems to keep the width so let's see how that works:

example patch:
`#N canvas 212 234 917 603 12;
#X obj 244 100 cyclone/coll bob @embed 1;
#C flags 1 0;
#C 0 500 1000 hi;
#C 1 5 10 hello;
#X f 61;
#C restore;
`