### PR TITLE
resizing for coll, funbuff, prob, table

### DIFF
--- a/cyclone_objects/binaries/audio/scope.c
+++ b/cyclone_objects/binaries/audio/scope.c
@@ -567,7 +567,7 @@ static void edit_proxy_any(t_edit_proxy *p, t_symbol *s, int ac, t_atom *av){
         || s == gensym("symbolatom") || s == gensym("text") || s == gensym("bng")
         || s == gensym("toggle") || s == gensym("numbox") || s == gensym("vslider")
         || s == gensym("hslider") || s == gensym("vradio") || s == gensym("hradio")
-        || s == gensym("vumeter") || s == gensym("mycnv")){
+        || s == gensym("vumeter") || s == gensym("mycnv") || s == gensym("selectall")){
             edit = 1;
         }
         else

--- a/cyclone_objects/binaries/control/coll.c
+++ b/cyclone_objects/binaries/control/coll.c
@@ -869,8 +869,9 @@ static void coll_embedhook(t_pd *z, t_binbuf *bb, t_symbol *bindsym){
             binbuf_add(bb, cnt, at);
             binbuf_add(bb, ep->e_size, ep->e_data);
             binbuf_addsemi(bb);
-        }
-    }
+        };
+    };
+    if(x->x_ob.te_width != 0) binbuf_addv(bb, "ssf;", &s__X, gensym("f"), (float)x->x_ob.te_width);
 }
 
 static void collcommon_editorhook(t_pd *z, t_symbol *s, int ac, t_atom *av){
@@ -2053,3 +2054,4 @@ CYCLONE_OBJ_API void coll_setup(void){
        have it around, just in case... */
     hammerfile_setup(collcommon_class, 0);
 }
+

--- a/cyclone_objects/binaries/control/comment.c
+++ b/cyclone_objects/binaries/control/comment.c
@@ -745,7 +745,7 @@ static void edit_proxy_any(t_edit_proxy *p, t_symbol *s, int ac, t_atom *av){
         || s == gensym("symbolatom") || s == gensym("text") || s == gensym("bng")
         || s == gensym("toggle") || s == gensym("numbox") || s == gensym("vslider")
         || s == gensym("hslider") || s == gensym("vradio") || s == gensym("hradio")
-        || s == gensym("vumeter") || s == gensym("mycnv")){
+        || s == gensym("vumeter") || s == gensym("mycnv") || s == gensym("selectall")){
             edit = 1;
         }
         else

--- a/documentation/help_files/comment-help.pd
+++ b/documentation/help_files/comment-help.pd
@@ -6,7 +6,7 @@
 #X text 170 434 (none);
 #X obj 3 529 cnv 15 552 21 empty empty empty 20 12 0 14 -233017 -33289
 0;
-#X text 113 152 <= the default comment box from [cyclone/comment];
+#X text 121 152 <= the default comment box from [cyclone/comment];
 #X obj 156 189 cyclone/comment 259 20 Times empty 3 150 0 0 1 230 235
 240 1 1 Hello \, I'm a comment from the [cyclone/comment] object!!!
 ;
@@ -153,27 +153,26 @@ text from comment into Pd (control+c / control+v doesn't work)., f
 #X connect 34 0 35 0;
 #X connect 35 0 8 0;
 #X restore 479 166 pd details;
-#N canvas 760 98 479 429 more 0;
-#X obj 145 300 cyclone/comment 151 20 dejavu\ sans\ mono empty 0 0
-0 0 0 200 200 200 1 0 comment can be justified in different ways;
-#X msg 145 265 textjustification \$1;
-#X obj 145 183 vradio 15 1 0 3 empty empty empty 0 -8 0 10 -228856
--1 -1 0;
-#X floatatom 145 240 3 0 0 0 - - -;
-#X text 163 182 left;
-#X text 163 197 center;
-#X text 163 213 right;
-#X text 58 29 By default \, [comment] has a maximum width limit of
+#N canvas 800 75 549 514 more 0;
+#X obj 188 340 cyclone/comment 151 20 dejavu\ sans\ mono empty 0 0
+0 0 0 200 200 200 1 1 comment can be justified in different ways;
+#X msg 188 305 textjustification \$1;
+#X obj 188 223 vradio 15 1 0 3 empty empty empty 0 -8 0 10 -228856
+-1 -1 1;
+#X floatatom 188 280 3 0 0 0 - - -;
+#X text 206 222 left;
+#X text 206 237 center;
+#X text 206 253 right;
+#X text 79 47 By default \, [comment] has a maximum width limit of
 425 pixels (like Pd's comment). If it exceeds this limit \, the comment
-will break into a new line with the last word that did not ft. But
-when in edit mode you can click near the outline at the end of the
-text (it's a bit tricky \, but it's by the end of the last character
-in the first line) and drag to set a new maximum width to the point
-where you release the mouse button., f 63;
-#X text 58 114 And when you have more than one line \, you can set
-three kinds of justification: left (0: default) \, center (1) and right
-(2). This does not affect the first line \, so it's irrelevant for
-comments with just one line., f 63;
+will break into a new line with the last word that did not fit. But
+when in edit mode you can see a bar to the right that allows you to
+resize the object. If you click and drag it \, you'll set a new maximum
+width to the point where you release the mouse button., f 66;
+#X text 79 128 And when you have more than one line \, you can set
+three kinds of justification parametrers: left (0: default) \, center
+(1) and right (2). This does not affect comments with just one line.
+, f 66;
 #X connect 1 0 0 0;
 #X connect 2 0 3 0;
 #X connect 3 0 1 0;


### PR DESCRIPTION
adding obj_saveformat instead of the binbuf_addv stuff (so changed coll too) because in theory it's more futureproof fif obj_saveformat changes in the future....

added this OUTSIDE of the if(embed) stuff for all the objects so it execute whether or not we choose to embed