### PR TITLE
Use standard PDLIBBUILDER_DIR variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,8 @@ endif
 
 ### pd-lib-builder ######################################################
 
-include pd-lib-builder/Makefile.pdlibbuilder
+PDLIBBUILDER_DIR=pd-lib-builder/
+include $(PDLIBBUILDER_DIR)/Makefile.pdlibbuilder
 
 ### linux aliases ######################################################
 


### PR DESCRIPTION
to allow overriding the used Makefile.pdlibbuilder with a system-specific (or updated) one.

See https://github.com/pure-data/pd-lib-builder/blob/master/tips-tricks.md#project-management for a rationale.