### PR TITLE
fix CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,12 +291,16 @@ add_library(cyclone_shared STATIC
     shared/common/grow.c
     shared/common/magicbit.h
     shared/common/magicbit.c
+    shared/common/random.h
+    shared/common/random.c
     shared/control/gui.h
     shared/control/gui.c
     shared/control/mifi.h
     shared/control/mifi.c
     shared/control/rand.h
     shared/control/rand.c
+    shared/control/s_cycloneutf8.h
+    shared/control/s_cycloneutf8.c
     shared/control/tree.h
     shared/control/tree.c
     shared/signal/cybuf.h

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You will be requested to provide a path to the pure-data sources and to the pure
 
 On macOS, you can define different deployment target and architectures from your current system using the variables `CMAKE_OSX_DEPLOYMENT_TARGET` and `CMAKE_OSX_ARCHITECTURES`.
 
-You can specify additional compilation flags using the variable `CMAKE_C_FLAGS`.
+You can specify additional compilation flags using the variable `CMAKE_C_FLAGS`. For example, if you have built libpd with multiple instance support, set `CMAKE_C_FLAGS` to `'-DPDINSTANCE=1'`.
 
 CMake can now generate Makefiles, a MSVC solution, or an XCode project.
 


### PR DESCRIPTION
I encountered the following errors while attempting to build a single library with CMake:
```
Undefined symbols for architecture arm64:
  "_cyclone_u8_dec", referenced from:
      _comment_key in libcomment.a[arm64][2](comment.c.o)
      _comment_key in libcomment.a[arm64][2](comment.c.o)
      _comment_key in libcomment.a[arm64][2](comment.c.o)
      _comment_key in libcomment.a[arm64][2](comment.c.o)
  "_cyclone_u8_inc", referenced from:
      _comment__click_callback in libcomment.a[arm64][2](comment.c.o)
      _comment_key in libcomment.a[arm64][2](comment.c.o)
      _comment_key in libcomment.a[arm64][2](comment.c.o)
      _comment_key in libcomment.a[arm64][2](comment.c.o)
      _comment_key in libcomment.a[arm64][2](comment.c.o)
      _comment_key in libcomment.a[arm64][2](comment.c.o)
      _comment_key in libcomment.a[arm64][2](comment.c.o)
      ...
  "_cyclone_u8_wc_nbytes", referenced from:
      _comment_key in libcomment.a[arm64][2](comment.c.o)
  "_cyget_seed", referenced from:
      _decide_seed in libdecide.a[arm64][2](decide.c.o)
      _pink_seed in libpink~.a[arm64][2](pink.c.o)
      _rand_seed in librand~.a[arm64][2](rand.c.o)
  "_cyrandom_frand", referenced from:
      _decide_bang in libdecide.a[arm64][2](decide.c.o)
      _decide_init in libdecide.a[arm64][2](decide.c.o)
      _pink_init in libpink~.a[arm64][2](pink.c.o)
      _pink_perform in libpink~.a[arm64][2](pink.c.o)
      _pink_perform in libpink~.a[arm64][2](pink.c.o)
      _rand_perform in librand~.a[arm64][2](rand.c.o)
  "_cyrandom_get_id", referenced from:
      _decide_new in libdecide.a[arm64][2](decide.c.o)
      _pink_new in libpink~.a[arm64][2](pink.c.o)
      _rand_new in librand~.a[arm64][2](rand.c.o)
  "_cyrandom_init", referenced from:
      _decide_seed in libdecide.a[arm64][2](decide.c.o)
      _pink_seed in libpink~.a[arm64][2](pink.c.o)
      _rand_seed in librand~.a[arm64][2](rand.c.o)
  "_cyrandom_trand", referenced from:
      _pink_perform in libpink~.a[arm64][2](pink.c.o)
ld: symbol(s) not found for architecture arm64
```

Then I noticed that CMakeLists.txt was not edited for around 7 years, so I checked which files were added and removed since then, and updated it accordingly.
```sh
git diff --name-status $(git log -n 1 --format=%H ./CMakeLists.txt)  HEAD | grep -Ev "^M|documentation|maintenance|md-help"

A       .gitattributes
A       .github/workflows/c-cpp.yml
D       cyclone_objects/abstractions/out~.pd
D       cyclone_objects/abstractions/setdsp~.pd
D       cyclone_objects/binaries/audio/curve.gp
D       cyclone_objects/binaries/audio/typeroute.c
A       shared/common/api.h
A       shared/common/random.c
A       shared/common/random.h
A       shared/control/s_cycloneutf8.c
A       shared/control/s_cycloneutf8.h
```